### PR TITLE
nvme: Add VFIO-backed NVMe controller support

### DIFF
--- a/example/upcie_nvme_driver.c
+++ b/example/upcie_nvme_driver.c
@@ -4,6 +4,11 @@
 #define _UPCIE_WITH_NVME
 #include <upcie/upcie.h>
 
+enum nvme_backend {
+	NVME_BACKEND_SYSFS = 0,
+	NVME_BACKEND_VFIO,
+};
+
 struct rte {
 	struct hostmem_config config;
 	struct hostmem_heap heap;
@@ -12,7 +17,50 @@ struct rte {
 struct nvme {
 	struct nvme_controller ctrlr;
 	struct nvme_qpair ioq;
+	struct vfio_ctx vfio;
+	enum nvme_backend backend;
 };
+
+static int
+device_get_driver_name(const char *bdf, char *driver_name, size_t driver_name_len)
+{
+	char path[PATH_MAX] = {0};
+	char link[PATH_MAX] = {0};
+	ssize_t nbytes;
+	char *base;
+
+	snprintf(path, sizeof(path), "/sys/bus/pci/devices/%s/driver", bdf);
+
+	nbytes = readlink(path, link, sizeof(link) - 1);
+	if (nbytes < 0) {
+		return -errno;
+	}
+
+	base = strrchr(link, '/');
+	if (!base || !base[1]) {
+		return -EINVAL;
+	}
+
+	snprintf(driver_name, driver_name_len, "%s", base + 1);
+
+	return 0;
+}
+
+static void
+nvme_cleanup(struct nvme *nvme)
+{
+	if (nvme->ioq.rpool) {
+		nvme_qpair_term(&nvme->ioq);
+		memset(&nvme->ioq, 0, sizeof(nvme->ioq));
+	}
+
+	if (nvme->backend == NVME_BACKEND_VFIO) {
+		nvme_controller_close_vfio(&nvme->ctrlr, &nvme->vfio);
+		return;
+	}
+
+	nvme_controller_close(&nvme->ctrlr);
+}
 
 int
 rte_init(struct rte *rte)
@@ -37,11 +85,27 @@ rte_init(struct rte *rte)
 int
 nvme_init(struct nvme *nvme, const char *bdf, struct rte *rte)
 {
+	char driver_name[NAME_MAX + 1] = {0};
 	struct nvme_completion cpl = {0};
 	struct nvme_command cmd = {0};
 	int err;
 
-	err = nvme_controller_open(&nvme->ctrlr, bdf, &rte->heap);
+	err = device_get_driver_name(bdf, driver_name, sizeof(driver_name));
+	if (err) {
+		printf("FAILED: device_get_driver_name(); err(%d)\n", err);
+		return -err;
+	}
+
+	if (!strcmp(driver_name, "vfio-pci")) {
+		nvme->backend = NVME_BACKEND_VFIO;
+		err = nvme_controller_open_vfio(&nvme->ctrlr, &nvme->vfio, bdf, &rte->heap);
+	} else if (!strcmp(driver_name, "uio_pci_generic")) {
+		nvme->backend = NVME_BACKEND_SYSFS;
+		err = nvme_controller_open(&nvme->ctrlr, bdf, &rte->heap);
+	} else {
+		printf("FAILED: unsupported driver '%s'\n", driver_name);
+		return -ENOTSUP;
+	}
 	if (err) {
 		printf("FAILED: nvme_device_open(); err(%d)\n", err);
 		return -err;
@@ -55,7 +119,7 @@ nvme_init(struct nvme *nvme, const char *bdf, struct rte *rte)
 						 nvme->ctrlr.timeout_ms, &cpl);
 	if (err) {
 		printf("FAILED: nvme_qpair_submit_sync(); err(%d)\n", err);
-		nvme_controller_close(&nvme->ctrlr);
+		nvme_cleanup(nvme);
 		return err;
 	}
 
@@ -65,7 +129,13 @@ nvme_init(struct nvme *nvme, const char *bdf, struct rte *rte)
 	err = nvme_controller_create_io_qpair(&nvme->ctrlr, &nvme->ioq, 32);
 	if (err) {
 		printf("FAILED: nvme_device_create_io_qpair(); err(%d)\n", err);
-		nvme_controller_close(&nvme->ctrlr);
+
+		if (nvme->backend == NVME_BACKEND_VFIO) {
+			nvme_controller_close_vfio(&nvme->ctrlr, &nvme->vfio);
+		} else {
+			nvme_controller_close(&nvme->ctrlr);
+		}
+
 		return err;
 	}
 
@@ -93,10 +163,11 @@ main(int argc, char **argv)
 	err = nvme_init(&nvme, argv[1], &rte);
 	if (err) {
 		printf("FAILED: nvme_init();");
+		hostmem_heap_term(&rte.heap);
 		return -err;
 	}
 
-	nvme_controller_close(&nvme.ctrlr);
+	nvme_cleanup(&nvme);
 	hostmem_heap_term(&rte.heap);
 
 	return err;

--- a/include/upcie/nvme/nvme_controller.h
+++ b/include/upcie/nvme/nvme_controller.h
@@ -83,6 +83,7 @@ nvme_controller_open(struct nvme_controller *ctrlr, const char *bdf, struct host
 	bar0 = ctrlr->func.bars[0].region;
 
 	cap = nvme_mmio_cap_read(bar0);
+	// CAP.TO is encoded in units of 500 ms.
 	ctrlr->timeout_ms = nvme_reg_cap_get_to(cap) * 500;
 
 	nvme_mmio_cc_disable(bar0);

--- a/include/upcie/nvme/nvme_controller_vfio.h
+++ b/include/upcie/nvme/nvme_controller_vfio.h
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Jaeyoon Choi <j_yoon.choi@samsung.com>
+
+/**
+ * VFIO state needed to access a single NVMe controller from user space.
+ */
+struct vfio_ctx {
+	struct vfio_container container;
+	struct vfio_group group;
+	int device_fd;
+	void *bar0;
+	size_t bar0_size;
+	int iommu_set;
+};
+
+static inline void
+nvme_vfio_ctx_init(struct vfio_ctx *vfio)
+{
+	memset(vfio, 0, sizeof(*vfio));
+	vfio->device_fd = -1;
+	vfio->group.fd = -1;
+	vfio->container.fd = -1;
+}
+
+/**
+ * Release VFIO resources and undo DMA mappings created for the heap.
+ */
+static inline int
+nvme_vfio_ctx_close(struct vfio_ctx *vfio, struct hostmem_heap *heap)
+{
+	int err = 0;
+
+	if (vfio->bar0 && vfio->bar0_size) {
+		munmap(vfio->bar0, vfio->bar0_size);
+	}
+
+	if (vfio->device_fd >= 0) {
+		close(vfio->device_fd);
+	}
+
+	if (heap && vfio->iommu_set) {
+		for (size_t i = 0; i < heap->nphys; ++i) {
+			struct vfio_iommu_type1_dma_unmap unmap = {0};
+
+			unmap.argsz = sizeof(unmap);
+			unmap.iova = heap->phys_lut[i];
+			unmap.size = heap->config->hugepgsz;
+
+			if (vfio_iommu_unmap_dma(&vfio->container, &unmap) < 0 && !err) {
+				err = -errno;
+			}
+		}
+	}
+
+	if (vfio->group.fd >= 0) {
+		vfio_group_close(&vfio->group);
+	}
+
+	if (vfio->container.fd >= 0) {
+		vfio_container_close(&vfio->container);
+	}
+
+	nvme_vfio_ctx_init(vfio);
+
+	return err;
+}
+
+static inline int
+nvme_controller_disable_vfio(const struct nvme_controller *ctrlr, const struct vfio_ctx *vfio)
+{
+	if (!vfio->bar0) {
+		return 0;
+	}
+
+	nvme_mmio_cc_disable(vfio->bar0);
+	if (!ctrlr->timeout_ms) {
+		return 0;
+	}
+
+	return nvme_mmio_csts_wait_until_not_ready(vfio->bar0, ctrlr->timeout_ms);
+}
+
+static inline int
+nvme_controller_close_vfio(struct nvme_controller *ctrlr, struct vfio_ctx *vfio)
+{
+	int close_err;
+	int err;
+
+	// Stop the controller before tearing down DMA mappings and BAR access.
+	err = nvme_controller_disable_vfio(ctrlr, vfio);
+
+	if (ctrlr->aq.rpool) {
+		nvme_qpair_term(&ctrlr->aq);
+		memset(&ctrlr->aq, 0, sizeof(ctrlr->aq));
+	}
+
+	if (ctrlr->buf) {
+		hostmem_dma_free(ctrlr->heap, ctrlr->buf);
+		ctrlr->buf = NULL;
+	}
+
+	close_err = nvme_vfio_ctx_close(vfio, ctrlr->heap);
+	if (close_err && !err) {
+		err = close_err;
+	}
+	memset(ctrlr, 0, sizeof(*ctrlr));
+
+	return err;
+}
+
+/**
+ * Resolve the IOMMU group ID of the PCI function identified by `bdf`.
+ */
+static inline int
+vfio_device_get_iommu_group_id(const char *bdf, int *group_id)
+{
+	char path[PATH_MAX] = {0};
+	char link[PATH_MAX] = {0};
+	ssize_t nbytes;
+	char *base;
+
+	snprintf(path, sizeof(path), "/sys/bus/pci/devices/%s/iommu_group", bdf);
+
+	nbytes = readlink(path, link, sizeof(link) - 1);
+	if (nbytes < 0) {
+		return -errno;
+	}
+
+	base = strrchr(link, '/');
+	if (!base || !base[1]) {
+		return -EINVAL;
+	}
+
+	*group_id = atoi(base + 1);
+
+	return 0;
+}
+
+/**
+ * Map the hugepage-backed heap into the VFIO IOMMU domain.
+ *
+ * The current implementation intentionally uses `iova == phys` for each hugepage.
+ * This keeps the existing NVMe code paths working because they already pass
+ * hostmem_dma_v2p() results to the controller for SQ/CQ/PRP DMA addresses.
+ *
+ * TODO: decouple IOVA from physical addresses by introducing a dedicated
+ *       hostmem_dma_v2iova() path for VFIO-backed DMA.
+ */
+static inline int
+vfio_map_heap(struct vfio_ctx *vfio, struct hostmem_heap *heap)
+{
+	for (size_t i = 0; i < heap->nphys; ++i) {
+		struct vfio_iommu_type1_dma_map map = {0};
+		void *vaddr = (uint8_t *)heap->memory.virt + (i * heap->config->hugepgsz);
+
+		map.argsz = sizeof(map);
+		map.flags = VFIO_DMA_MAP_FLAG_READ | VFIO_DMA_MAP_FLAG_WRITE;
+		map.vaddr = (uintptr_t)vaddr;
+		map.iova = heap->phys_lut[i];
+		map.size = heap->config->hugepgsz;
+
+		if (vfio_iommu_map_dma(&vfio->container, &map) < 0) {
+			UPCIE_DEBUG("FAILED: vfio_iommu_map_dma(); errno(%d)", errno);
+			return -errno;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * Open an NVMe controller through VFIO.
+ *
+ * This sets up the VFIO container/group, maps the DMA heap and BAR0, and then
+ * continues with the regular NVMe controller initialization flow.
+ */
+static inline int
+nvme_controller_open_vfio(struct nvme_controller *ctrlr, struct vfio_ctx *vfio, const char *bdf,
+			  struct hostmem_heap *heap)
+{
+	struct vfio_region_info region = {0};
+	int api_version = 0;
+	int group_id = -1;
+	uint64_t cap;
+	void *bar0;
+	int err;
+
+	memset(ctrlr, 0, sizeof(*ctrlr));
+	nvme_vfio_ctx_init(vfio);
+	ctrlr->heap = heap;
+
+	ctrlr->buf = hostmem_dma_malloc(ctrlr->heap, 4096);
+	if (!ctrlr->buf) {
+		UPCIE_DEBUG("FAILED: hostmem_dma_malloc(buf); errno(%d)", errno);
+		return -errno;
+	}
+	memset(ctrlr->buf, 0, 4096);
+
+	nvme_qid_bitmap_init(ctrlr->qids);
+
+	// Set up VFIO resources
+	err = vfio_device_get_iommu_group_id(bdf, &group_id);
+	if (err) {
+		UPCIE_DEBUG("FAILED: vfio_device_get_iommu_group_id(); err(%d)", err);
+		goto fail;
+	}
+
+	err = vfio_container_open(&vfio->container);
+	if (err) {
+		UPCIE_DEBUG("FAILED: vfio_container_open(); err(%d)", err);
+		goto fail;
+	}
+
+	err = vfio_get_api_version(&vfio->container, &api_version);
+	if (err) {
+		UPCIE_DEBUG("FAILED: vfio_get_api_version(); err(%d)", err);
+		goto fail;
+	}
+	if (api_version != VFIO_API_VERSION) {
+		err = -EINVAL;
+		UPCIE_DEBUG("FAILED: unexpected VFIO_API_VERSION(%d != %d)", api_version,
+			    VFIO_API_VERSION);
+		goto fail;
+	}
+
+	if (!vfio_check_extension(&vfio->container, VFIO_TYPE1_IOMMU)) {
+		err = -ENOTSUP;
+		UPCIE_DEBUG("FAILED: VFIO_TYPE1_IOMMU not supported");
+		goto fail;
+	}
+
+	err = vfio_group_open(group_id, &vfio->group);
+	if (err) {
+		UPCIE_DEBUG("FAILED: vfio_group_open(%d); err(%d)", group_id, err);
+		goto fail;
+	}
+
+	err = vfio_group_get_status(&vfio->group);
+	if (err < 0) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: vfio_group_get_status(); errno(%d)", errno);
+		goto fail;
+	}
+
+	if (!(vfio->group.status.flags & VFIO_GROUP_FLAGS_VIABLE)) {
+		err = -EBUSY;
+		UPCIE_DEBUG("FAILED: group not viable");
+		goto fail;
+	}
+
+	err = vfio_group_set_container(&vfio->group, &vfio->container);
+	if (err < 0) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: vfio_group_set_container(); errno(%d)", errno);
+		goto fail;
+	}
+
+	err = vfio_set_iommu(&vfio->container, VFIO_TYPE1_IOMMU);
+	if (err < 0) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: vfio_set_iommu(); errno(%d)", errno);
+		goto fail;
+	}
+	vfio->iommu_set = 1;
+
+	err = vfio_map_heap(vfio, heap);
+	if (err) {
+		UPCIE_DEBUG("FAILED: vfio_map_heap(); err(%d)", err);
+		goto fail;
+	}
+
+	vfio->device_fd = vfio_group_get_device_fd(&vfio->group, bdf);
+	if (vfio->device_fd < 0) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: vfio_group_get_device_fd(); errno(%d)", errno);
+		goto fail;
+	}
+
+	region.index = VFIO_PCI_BAR0_REGION_INDEX;
+	err = vfio_device_get_region_info(vfio->device_fd, &region);
+	if (err < 0) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: vfio_device_get_region_info(); errno(%d)", errno);
+		goto fail;
+	}
+
+	bar0 = vfio_map_region(vfio->device_fd, region.size, region.offset);
+	if (bar0 == MAP_FAILED) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: vfio_map_region(); errno(%d)", errno);
+		goto fail;
+	}
+
+	vfio->bar0 = bar0;
+	vfio->bar0_size = region.size;
+	ctrlr->func.bars[0].region = bar0;
+	ctrlr->func.bars[0].size = region.size;
+	ctrlr->func.bars[0].id = 0;
+	ctrlr->func.bars[0].fd = vfio->device_fd;
+
+	// Continue with the common NVMe controller initialization
+	cap = nvme_mmio_cap_read(bar0);
+	// CAP.TO is encoded in units of 500 ms.
+	ctrlr->timeout_ms = nvme_reg_cap_get_to(cap) * 500;
+
+	nvme_mmio_cc_disable(bar0);
+
+	err = nvme_mmio_csts_wait_until_not_ready(bar0, ctrlr->timeout_ms);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_mmio_csts_wait_until_not_ready(); err(%d)", err);
+		goto fail;
+	}
+
+	err = nvme_qpair_init(&ctrlr->aq, 0, 256, bar0, ctrlr->heap);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_qpair_init(aq); err(%d)", err);
+		goto fail;
+	}
+
+	nvme_mmio_aq_setup(bar0, hostmem_dma_v2p(heap, ctrlr->aq.sq),
+			   hostmem_dma_v2p(heap, ctrlr->aq.cq), ctrlr->aq.depth);
+
+	{
+		uint32_t css = (nvme_reg_cap_get_css(cap) & (1 << 6)) ? 0x6 : 0x0;
+		uint32_t cc = 0;
+
+		cc = nvme_reg_cc_set_css(cc, css);
+		cc = nvme_reg_cc_set_shn(cc, 0x0);
+		cc = nvme_reg_cc_set_mps(cc, 0x0);
+		cc = nvme_reg_cc_set_ams(cc, 0x0);
+		cc = nvme_reg_cc_set_iosqes(cc, 6);
+		cc = nvme_reg_cc_set_iocqes(cc, 4);
+		cc = nvme_reg_cc_set_en(cc, 0x1);
+
+		nvme_mmio_cc_write(bar0, cc);
+	}
+
+	err = nvme_mmio_csts_wait_until_ready(bar0, ctrlr->timeout_ms);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_mmio_csts_wait_until_ready(); err(%d)", err);
+		goto fail;
+	}
+
+	return 0;
+
+fail:
+	nvme_controller_close_vfio(ctrlr, vfio);
+
+	return err;
+}

--- a/include/upcie/upcie.h
+++ b/include/upcie/upcie.h
@@ -87,6 +87,7 @@ extern "C" {
 #include <upcie/nvme/nvme_qid.h>
 #include <upcie/nvme/nvme_qpair.h>
 #include <upcie/nvme/nvme_controller.h>
+#include <upcie/nvme/nvme_controller_vfio.h>
 #endif
 
 #ifdef __cplusplus

--- a/meson.build
+++ b/meson.build
@@ -41,6 +41,7 @@ install_headers(
     'include/upcie/mmio.h',
     'include/upcie/nvme/nvme_command.h',
     'include/upcie/nvme/nvme_controller.h',
+    'include/upcie/nvme/nvme_controller_vfio.h',
     'include/upcie/nvme/nvme_mmio.h',
     'include/upcie/nvme/nvme_qid.h',
     'include/upcie/nvme/nvme_qpair.h',


### PR DESCRIPTION
## Summary

Add a VFIO-backed NVMe controller path and update the example driver to
select the backend from the driver bound to the requested BDF.

## Changes

- add VFIO-based controller open/close helpers
- map the DMA heap into the VFIO IOMMU domain and map BAR0 through VFIO
- update the example to support both `vfio-pci` and `uio_pci_generic`

## Note

The current VFIO mapping still assumes `IOVA == physical address`. A
follow-up should introduce a dedicated IOVA translation path instead of
reusing `hostmem_dma_v2p()` results directly.

## Testing
### IOMMU enable
```
$ sudo vim /etc/default/grub
`GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"`
$ sudo update-grub
$ sudo reboot

$ cat /proc/cmdline 
$ sudo dmesg | grep -i -E 'DMAR|IOMMU' 
$ readlink -f /sys/bus/pci/devices/0000:02:00.0/iommu_group
```

### Hugepage 
```
$ sudo ./scripts/hugepages.py setup --size 2048 --count 128
# INFO: /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages "128"
$ cat /proc/sys/vm/nr_hugepages
128
```

### Bind the vfio-pci driver
```
$ sudo modprobe vfio-pci
$ echo vfio-pci | sudo tee /sys/bus/pci/devices/0000:02:00.0/driver_override
$ echo 0000:02:00.0 | sudo tee /sys/bus/pci/devices/0000:02:00.0/driver/unbind
$ echo 0000:02:00.0 | sudo tee /sys/bus/pci/drivers/vfio-pci/bind
```
```
$ lspci -nnk -s 02:00.0
$ ls -l /dev/vfio /dev/vfio/19
```
### Run
```
$ sudo ./builddir/example/upcie_nvme_driver 0000:02:00.0
```