### PR TITLE
feat(cudamem): added memory mapping of externally allocated CUDA buffers

### DIFF
--- a/include/upcie/cudamem_config.h
+++ b/include/upcie/cudamem_config.h
@@ -8,15 +8,34 @@
  * size, cudamem_config tracks both the host page size (used for PRP
  * construction and NVMe alignment) and the GPU device page size (the dma-buf
  * page granularity for memory allocated via cuMemAlloc).
+ *
+ * It also stashes the total device memory and BAR1 size, both used by
+ * downstream consumers: device_memsize sizes the cudamem_mapping_registry
+ * LUT, and bar1_size is verified to be at least as large as device_memsize at
+ * init time (a precondition for PCIe P2P DMA against arbitrary device pages).
+ *
+ * Caveat: Single-GPU usage
+ * ------------------------
+ *
+ * One config describes one device. Process-wide multi-GPU usage requires one
+ * cudamem_config (and one cudamem_mapping_registry, one cudamem_heap) per GPU.
  */
 
 /**
  * Memory properties for CUDA device memory
  */
 struct cudamem_config {
-	int pagesize;       ///< Host page size (e.g. 4 KB); used for NVMe PRP and allocation alignment
-	int pagesize_shift; ///< pagesize expressed as a power of two: pagesize == 1 << pagesize_shift
-	int device_pagesize;  ///< GPU device page size (dma-buf page granularity for cuMemAlloc memory)
+	int pagesize; ///< Host page size (e.g. 4 KB); used for NVMe PRP and allocation alignment
+	int pagesize_shift;    ///< pagesize expressed as a power of two: pagesize == 1 <<
+			       ///< pagesize_shift
+	int device_pagesize;   ///< GPU device page size (dma-buf page granularity for cuMemAlloc
+			       ///< memory)
+	size_t device_memsize; ///< Total GPU device memory in bytes (cuDeviceTotalMem)
+	size_t bar1_size;      ///< Size of the GPU's BAR1 region in bytes
+	size_t alloc_granularity;    ///< cuMemAlloc VA reservation unit and BAR1 large-page
+				     ///< size; queried via cuMemGetAllocationGranularity
+	int alloc_granularity_shift; ///< alloc_granularity expressed as a power of two:
+				     ///< alloc_granularity == 1 << alloc_granularity_shift
 };
 
 static inline int
@@ -32,31 +51,60 @@ cudamem_config_pp(struct cudamem_config *config)
 	}
 
 	wrtn += printf("\n");
-	wrtn += printf("  pagesize:      %d\n", config->pagesize);
-	wrtn += printf("  pagesize_shift:%d\n", config->pagesize_shift);
-	wrtn += printf("  device_pagesize: %d\n", config->device_pagesize);
+	wrtn += printf("  pagesize:                %d\n", config->pagesize);
+	wrtn += printf("  pagesize_shift:          %d\n", config->pagesize_shift);
+	wrtn += printf("  device_pagesize:         %d\n", config->device_pagesize);
+	wrtn += printf("  device_memsize:          %zu\n", config->device_memsize);
+	wrtn += printf("  bar1_size:               %zu\n", config->bar1_size);
+	wrtn += printf("  alloc_granularity:       %zu\n", config->alloc_granularity);
+	wrtn += printf("  alloc_granularity_shift: %d\n", config->alloc_granularity_shift);
 
 	return wrtn;
 }
 
 /**
- * Initialize cudamem_config by querying the host page size and setting the GPU
- * device page size.
+ * Initialize cudamem_config by querying host page size, GPU device page size,
+ * total device memory, and BAR1 size.
  *
  * The device page size is fixed at 64 KB: this is the dma-buf page granularity
  * for memory allocated via cuMemAlloc on all NVIDIA GPUs. It is distinct from
  * the minimum granularity returned by cuMemGetAllocationGranularity, which
  * applies only to the virtual memory management API (cuMemCreate/cuMemMap).
  *
+ * `alloc_granularity` is queried via cuMemGetAllocationGranularity with
+ * CU_MEM_ALLOC_GRANULARITY_MINIMUM. The CUDA documentation defines this for
+ * the VMM API, but cudamem_mapping reuses the same value as the BAR1
+ * large-page size for cuMemAlloc-backed memory: on NVIDIA GPUs the kernel
+ * driver maps both VMM and cuMemAlloc allocations through the same BAR1
+ * page-table large-page mechanism, so the VMM minimum reservation unit
+ * matches the contiguous IOVA window each cuMemAlloc chunk occupies. The
+ * contiguity check in cudamem_mapping_chunk_populate (returning -EOPNOTSUPP
+ * when violated) catches a hardware/driver mismatch at runtime.
+ *
+ * BAR1 size is read via pci_bar_size(bdf, 1, ...), where <bdf> is obtained
+ * from cuDeviceGetPCIBusId(). The PCI BAR index 1 follows NVIDIA's discrete
+ * GPU convention (BAR0 is 32-bit MMIO, BAR1 is the framebuffer aperture); a
+ * 64-bit BAR0 layout (consuming registers 0 and 1) would shift the FB
+ * aperture to resource2 and is not supported. The function fails if BAR1
+ * size is smaller than total device memory: PCIe P2P DMA over the full
+ * device memory range requires the BAR1 to span it, which in turn requires
+ * resizable BAR (or a similarly sized fixed BAR) to be enabled in firmware.
+ *
  * @param config  Pointer to the config struct to initialize
- * @param gpu_id  CUDA device ordinal (unused, reserved for future use)
+ * @param gpu_id  CUDA device ordinal
  *
  * @return 0 on success, negative errno on failure.
  */
 static inline int
 cudamem_config_init(struct cudamem_config *config, int gpu_id)
 {
-	(void)gpu_id;
+	char bdf[PCI_BDF_LEN + 1] = {0};
+	CUmemAllocationProp prop = {0};
+	CUdevice dev;
+	size_t total_mem = 0;
+	size_t gran = 0;
+	CUresult cr;
+	int err;
 
 	if (!config) {
 		return -EINVAL;
@@ -65,6 +113,62 @@ cudamem_config_init(struct cudamem_config *config, int gpu_id)
 	config->pagesize = getpagesize();
 	config->pagesize_shift = upcie_util_shift_from_size(config->pagesize);
 	config->device_pagesize = 65536;
+
+	cr = cuDeviceGet(&dev, gpu_id);
+	if (cr != CUDA_SUCCESS) {
+		UPCIE_DEBUG("FAILED: cuDeviceGet(gpu_id=%d), cr: %d", gpu_id, cr);
+		return -ENODEV;
+	}
+
+	cr = cuDeviceTotalMem(&total_mem, dev);
+	if (cr != CUDA_SUCCESS) {
+		UPCIE_DEBUG("FAILED: cuDeviceTotalMem(), cr: %d", cr);
+		return -EIO;
+	}
+	config->device_memsize = total_mem;
+
+	cr = cuDeviceGetPCIBusId(bdf, sizeof(bdf), dev);
+	if (cr != CUDA_SUCCESS) {
+		UPCIE_DEBUG("FAILED: cuDeviceGetPCIBusId(), cr: %d", cr);
+		return -EIO;
+	}
+
+	/* cuDeviceGetPCIBusId returns uppercase hex; sysfs uses lowercase. */
+	for (int i = 0; bdf[i]; i++) {
+		if (bdf[i] >= 'A' && bdf[i] <= 'F') {
+			bdf[i] = bdf[i] - 'A' + 'a';
+		}
+	}
+
+	err = pci_bar_size(bdf, 1, &config->bar1_size);
+	if (err) {
+		UPCIE_DEBUG("FAILED: pci_bar_size(%s, 1), err: %d", bdf, err);
+		return err;
+	}
+
+	if (config->bar1_size < config->device_memsize) {
+		UPCIE_DEBUG("FAILED: BAR1(%zu) < device_memsize(%zu); enable resizable BAR in "
+			    "firmware",
+			    config->bar1_size, config->device_memsize);
+		return -EOPNOTSUPP;
+	}
+
+	prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+	prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+	prop.location.id = (int)dev;
+
+	cr = cuMemGetAllocationGranularity(&gran, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM);
+	if (cr != CUDA_SUCCESS) {
+		UPCIE_DEBUG("FAILED: cuMemGetAllocationGranularity(), cr: %d", cr);
+		return -EIO;
+	}
+	if (!gran || (gran & (gran - 1))) {
+		UPCIE_DEBUG("FAILED: cuMemGetAllocationGranularity returned non-power-of-two: %zu",
+			    gran);
+		return -EINVAL;
+	}
+	config->alloc_granularity = gran;
+	config->alloc_granularity_shift = upcie_util_shift_from_size(gran);
 
 	return 0;
 }

--- a/include/upcie/cudamem_heap.h
+++ b/include/upcie/cudamem_heap.h
@@ -378,6 +378,19 @@ cudamem_heap_block_alloc(struct cudamem_heap *heap, size_t size)
 }
 
 /**
+ * Test whether a virtual address falls inside the given heap's range.
+ *
+ * @return 1 if `virt` is inside the heap, 0 otherwise.
+ */
+static inline int
+cudamem_heap_contains(struct cudamem_heap *heap, void *virt)
+{
+	uint64_t vaddr = (uint64_t)virt;
+
+	return heap && vaddr >= heap->vaddr && vaddr < heap->vaddr + heap->size;
+}
+
+/**
  * Calculate the physical address of a block on the given heap
  */
 static inline int

--- a/include/upcie/cudamem_mapping.h
+++ b/include/upcie/cudamem_mapping.h
@@ -1,0 +1,527 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+/**
+ * Registry of externally-allocated CUDA buffers for NVMe DMA
+ * ==========================================================
+ *
+ * Where cudamem_heap pre-allocates a single dma-buf-backed range and serves
+ * sub-allocations from it, cudamem_mapping registers buffers that the caller
+ * already allocated (via cuMemAlloc, cuMemCreate/cuMemMap, or cudaMalloc) and
+ * builds a physical address LUT for them via the same dma-buf interface.
+ *
+ * Chunk-cached design
+ * -------------------
+ *
+ * The registry caches one dma-buf per `alloc_granularity`-aligned VA chunk
+ * (typically 2 MiB on NVIDIA discrete GPUs, queried via
+ * cuMemGetAllocationGranularity at config_init time). Each chunk's BAR1 IOVA
+ * window is contiguous (BAR1 page-table large-page guarantee), so each chunk
+ * has one `phys_base` (held in `lut_phys[chunk_idx]`), and per-page phys is
+ * computed during virt_to_phys as
+ *
+ *     phys = lut_phys[chunk_idx] + (vaddr & (alloc_granularity - 1))
+ *
+ * `_add` walks chunks intersecting the floored user range, ref-bumps existing
+ * entries, and populates new entries via cuMemGetHandleForAddressRange +
+ * dmabuf_attach + dmabuf_get_lut. `_remove` decrements rc and frees the dma-buf
+ * when rc reaches zero. Repeated overlapping registrations in the same chunk
+ * amortize to one dma-buf cost, and resolve to identical phys for any VA they
+ * share.
+ *
+ * Registrations and chunks form a many-to-many relationship: one registration
+ * may span multiple chunks (large or chunk-boundary-crossing buffers), and one
+ * chunk may be referenced by multiple registrations (sub-granularity
+ * allocations packed by the driver). The chunk's `rc` counts the latter.
+ *
+ * Lookup table layout
+ * -------------------
+ *
+ * Chunks are indexed directly by chunk_idx = vaddr >> alloc_granularity_shift,
+ * over the full user virtual address space (CUDAMEM_MAPPING_VA_BITS, default
+ * 48). Two parallel arrays cover the chunk_idx range:
+ *
+ *   lut_phys[chunk_idx] -> uint64_t phys_base (0 == unmapped)
+ *   lut_meta[chunk_idx] -> { rc, dmabuf attach }  (cold path only)
+ *
+ * Both are MAP_ANONYMOUS | MAP_PRIVATE | MAP_NORESERVE mmaps. The kernel
+ * demand-pages individual host pages on first write, so the physical footprint
+ * scales with live chunks rather than virtual capacity. With a 48-bit VA and
+ * 2 MiB granularity that is 1 GiB (lut_phys) + 4 GiB (lut_meta) of virtual
+ * reservation, but typically a few hundred KiB resident.
+ *
+ * The split keeps the hot path flat-array-of-u64: `_virt_to_phys` reads
+ * `lut_phys[chunk_idx]` only and never touches `lut_meta`.
+ *
+ * Caveat: Hardware requirements
+ * -----------------------------
+ *
+ * Same as cudamem_heap: requires a GPU with PCIe P2P DMA support and a BAR1
+ * region at least as large as device memory. cudamem_config_init() verifies the
+ * BAR1 precondition. Additionally, the chunk-cache assumes the BAR1 page-table
+ * maps each alloc_granularity-sized export as one contiguous IOVA range; on
+ * hardware violating this, _add returns -EOPNOTSUPP after detecting a
+ * non-contiguous LUT.
+ *
+ * Caveat: Single-GPU registry
+ * ---------------------------
+ *
+ * One registry describes one device. Multi-GPU usage requires one
+ * cudamem_mapping_registry per GPU (and one cudamem_config, one cudamem_heap
+ * each).
+ *
+ * Caveat: Virtual address width
+ * -----------------------------
+ *
+ * The LUT capacity assumes user vaddrs fit in CUDAMEM_MAPPING_VA_BITS bits.
+ * 48 bits covers x86-64 and ARM64 default page-table widths. Systems with
+ * LA57 or 52-bit ARM64 user VA may return vaddrs above this bound; on those
+ * systems the constant must be raised at compile time.
+ *
+ * Caveat: Virtual memory reservation
+ * ----------------------------------
+ *
+ * The two LUTs reserve 1 GiB (lut_phys) + 4 GiB (lut_meta) of virtual
+ * address space at 48-bit VA / 2 MiB granularity. They are MAP_NORESERVE,
+ * so no swap is committed and physical RSS scales with live chunks. On
+ * systems configured for strict accounting (vm.overcommit_memory=2) or
+ * inside cgroups whose memory.max counts virtual reservation, registry_init
+ * may return -ENOMEM. Workarounds are to relax the accounting policy or to
+ * lower CUDAMEM_MAPPING_VA_BITS to bound the reservation.
+ *
+ * Sentinel: lut_phys[idx] == 0
+ * ----------------------------
+ *
+ * `_virt_to_phys` treats `lut_phys[idx] == 0` as "chunk not registered".
+ * Phys 0 is a theoretically valid BAR1 base, but PCIe BAR1 is allocated by
+ * the host bridge into nonzero IOVA space in practice. Code paths that
+ * mutate state (`_add`, `_remove`, `_clear`) consult `lut_meta[idx].rc`
+ * directly and do not depend on this sentinel.
+ */
+
+/**
+ * Width of the user virtual address space, in bits, used to size the chunk
+ * LUTs.
+ */
+#define CUDAMEM_MAPPING_VA_BITS 48
+
+/**
+ * Per-chunk cache entry (cold-path only).
+ *
+ * Owns the dma-buf for one `alloc_granularity`-aligned VA chunk. `rc` counts
+ * the number of registrations whose floored range intersects this chunk.
+ * When rc transitions to zero the dma-buf is detached and the corresponding
+ * `lut_phys` slot is cleared.
+ *
+ * The chunk's `phys_base` is held in `lut_phys[chunk_idx]`, not here, so the
+ * hot path needs only one LUT load.
+ */
+struct cudamem_mapping_chunk_meta {
+	uint32_t rc;          ///< Refcount of overlapping registrations
+	struct dmabuf attach; ///< dma-buf attachment (valid when rc > 0)
+};
+
+/**
+ * Per-registration metadata.
+ *
+ * Tracks one (vaddr, size) registration so `_remove(vaddr)` can locate the
+ * chunks to deref. The chunk LUTs own the dma-bufs, not this struct.
+ */
+struct cudamem_mapping_registration {
+	uint64_t vaddr;                            ///< Virtual address of the registered range
+	size_t size;                               ///< Size of the registered range in bytes
+	struct cudamem_mapping_registration *next; ///< List linkage owned by the registry
+};
+
+/**
+ * Registry of all registrations for one CUDA device.
+ *
+ * Owns two demand-paged LUTs covering the full user VA space at chunk
+ * granularity: lut_phys (1 GiB virtual at 48-bit VA / 2 MiB gran) for the hot
+ * path and lut_meta (4 GiB virtual at 48-bit VA / 2 MiB gran) for the cold
+ * path, plus the linked list of registration metadata.
+ *
+ * `gran_shift` and `gran_mask` are derived from `cudamem_config.alloc_granularity`
+ * at init time and cached here so the LUT-only paths (`_virt_to_phys`,
+ * `_remove`, `_clear`) need no config reference. `_add` still takes the config
+ * as a separate argument because chunk population calls into CUDA.
+ */
+struct cudamem_mapping_registry {
+	int gran_shift;                              ///< alloc_granularity expressed as a power of two
+	uint64_t gran_mask;                          ///< alloc_granularity - 1, for chunk-offset masking
+	size_t lut_capacity;                         ///< Number of slots in each LUT
+	uint64_t *lut_phys;                          ///< chunk_idx -> phys_base; mmap-backed
+	struct cudamem_mapping_chunk_meta *lut_meta; ///< chunk_idx -> meta; mmap-backed
+	struct cudamem_mapping_registration *list;   ///< Owned list of registration metadata
+};
+
+/**
+ * Initialize a mapping registry for the given config.
+ *
+ * Reserves two demand-paged virtual ranges (lut_phys and lut_meta), each
+ * sized to (1 << CUDAMEM_MAPPING_VA_BITS) / alloc_granularity slots. No
+ * physical memory is committed until chunks are registered.
+ *
+ * Caches `gran_shift`, `gran_mask`, and `lut_capacity` derived from the
+ * config; the registry retains no pointer to the config struct, so the
+ * caller is free to discard it after init. `cudamem_mapping_add` takes the
+ * config as a separate argument since populating a chunk needs the full
+ * config (page size, etc.).
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static inline int
+cudamem_mapping_registry_init(struct cudamem_mapping_registry *registry,
+			      struct cudamem_config *config)
+{
+	size_t phys_bytes, meta_bytes;
+
+	if (!registry || !config) {
+		return -EINVAL;
+	}
+
+	registry->gran_shift = config->alloc_granularity_shift;
+	registry->gran_mask = (uint64_t)config->alloc_granularity - 1;
+	registry->lut_capacity = (1ULL << CUDAMEM_MAPPING_VA_BITS) >> registry->gran_shift;
+	registry->list = NULL;
+
+	phys_bytes = registry->lut_capacity * sizeof(*registry->lut_phys);
+	registry->lut_phys = mmap(NULL, phys_bytes, PROT_READ | PROT_WRITE,
+				  MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+	if (registry->lut_phys == MAP_FAILED) {
+		UPCIE_DEBUG("FAILED: mmap(lut_phys, %zu); errno: %d", phys_bytes, errno);
+		registry->lut_phys = NULL;
+		return -ENOMEM;
+	}
+
+	meta_bytes = registry->lut_capacity * sizeof(*registry->lut_meta);
+	registry->lut_meta = mmap(NULL, meta_bytes, PROT_READ | PROT_WRITE,
+				  MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+	if (registry->lut_meta == MAP_FAILED) {
+		UPCIE_DEBUG("FAILED: mmap(lut_meta, %zu); errno: %d", meta_bytes, errno);
+		munmap(registry->lut_phys, phys_bytes);
+		registry->lut_phys = NULL;
+		registry->lut_meta = NULL;
+		return -ENOMEM;
+	}
+
+	return 0;
+}
+
+/**
+ * Decrement rc on chunks [chunk_first, chunk_first + chunk_cnt) and detach
+ * the dma-buf for each chunk whose rc transitions to zero.
+ *
+ * Chunks with rc == 0 on entry are skipped, making the helper safe for
+ * partial unwind paths (where some chunks in the range were never bumped).
+ */
+static inline void
+cudamem_mapping_chunk_deref(struct cudamem_mapping_registry *registry, size_t chunk_first,
+			    size_t chunk_cnt)
+{
+	for (size_t k = 0; k < chunk_cnt; ++k) {
+		const size_t idx = chunk_first + k;
+		struct cudamem_mapping_chunk_meta *cm = &registry->lut_meta[idx];
+
+		if (cm->rc == 0) {
+			continue;
+		}
+		cm->rc--;
+		if (cm->rc == 0) {
+			dmabuf_detach(&cm->attach);
+			memset(&cm->attach, 0, sizeof(cm->attach));
+			registry->lut_phys[idx] = 0;
+		}
+	}
+}
+
+/**
+ * Detach all cached dma-bufs and free registration metadata.
+ *
+ * Walks the registration list and decrements each chunk's rc, releasing the
+ * dma-buf and clearing the lut_phys slot when rc reaches zero. The LUT mmaps
+ * stay reserved.
+ */
+static inline void
+cudamem_mapping_clear(struct cudamem_mapping_registry *registry)
+{
+	struct cudamem_mapping_registration *next;
+
+	if (!registry) {
+		return;
+	}
+
+	const uint64_t mask = registry->gran_mask;
+	const int gran_shift = registry->gran_shift;
+
+	for (struct cudamem_mapping_registration *m = registry->list; m; m = next) {
+		const size_t chunk_first = (size_t)(m->vaddr >> gran_shift);
+		const size_t chunk_cnt =
+			(size_t)(((m->vaddr & mask) + m->size + mask) >> gran_shift);
+
+		cudamem_mapping_chunk_deref(registry, chunk_first, chunk_cnt);
+
+		next = m->next;
+		free(m);
+	}
+	registry->list = NULL;
+}
+
+/**
+ * Tear down a registry, releasing the LUT mmaps and detaching all cached
+ * dma-bufs.
+ */
+static inline void
+cudamem_mapping_registry_term(struct cudamem_mapping_registry *registry)
+{
+	if (!registry) {
+		return;
+	}
+
+	cudamem_mapping_clear(registry);
+
+	if (registry->lut_phys) {
+		munmap(registry->lut_phys, registry->lut_capacity * sizeof(*registry->lut_phys));
+		registry->lut_phys = NULL;
+	}
+	if (registry->lut_meta) {
+		munmap(registry->lut_meta, registry->lut_capacity * sizeof(*registry->lut_meta));
+		registry->lut_meta = NULL;
+	}
+	registry->lut_capacity = 0;
+}
+
+/**
+ * Populate one chunk from CUDA.
+ *
+ * Calls cuMemGetHandleForAddressRange for the chunk's full alloc_granularity
+ * extent, attaches the dma-buf, fetches the host-page LUT, verifies that the
+ * LUT is contiguous (BAR1 large-page assumption), and returns the chunk's
+ * phys_base via *phys_base_out and the attachment via *attach_out. On any
+ * failure both outputs are left untouched and an errno is returned.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static inline int
+cudamem_mapping_chunk_populate(uint64_t *phys_base_out, struct dmabuf *attach_out,
+			       uint64_t chunk_va, struct cudamem_config *config)
+{
+	const size_t pagesize = (size_t)config->pagesize;
+	const size_t gran = config->alloc_granularity;
+	const size_t nphys = gran >> config->pagesize_shift;
+	uint64_t *tmp = NULL;
+	int dmabuf_fd = -1;
+	struct dmabuf attach = {0};
+	int err;
+	CUresult cr;
+
+	tmp = calloc(nphys, sizeof(*tmp));
+	if (!tmp) {
+		return -ENOMEM;
+	}
+
+	cr = cuMemGetHandleForAddressRange(&dmabuf_fd, (CUdeviceptr)chunk_va, gran,
+					   CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
+	if (cr != CUDA_SUCCESS) {
+		UPCIE_DEBUG("FAILED: cuMemGetHandleForAddressRange(0x%" PRIx64 ", %zu), cr: %d",
+			    chunk_va, gran, cr);
+		err = -EIO;
+		goto err_free;
+	}
+
+	err = dmabuf_attach(dmabuf_fd, &attach);
+	if (err) {
+		UPCIE_DEBUG("FAILED: dmabuf_attach(), err: %d", err);
+		close(dmabuf_fd);
+		goto err_free;
+	}
+
+	err = dmabuf_get_lut(&attach, nphys, tmp, (int)pagesize);
+	if (err) {
+		UPCIE_DEBUG("FAILED: dmabuf_get_lut(), err: %d", err);
+		goto err_detach;
+	}
+
+	for (size_t i = 1; i < nphys; ++i) {
+		if (tmp[i] != tmp[0] + i * pagesize) {
+			UPCIE_DEBUG("FAILED: chunk LUT not contiguous at i=%zu; phys[0]=0x%" PRIx64
+				    " phys[%zu]=0x%" PRIx64,
+				    i, tmp[0], i, tmp[i]);
+			err = -EOPNOTSUPP;
+			goto err_detach;
+		}
+	}
+
+	*phys_base_out = tmp[0];
+	*attach_out = attach;
+	free(tmp);
+	return 0;
+
+err_detach:
+	dmabuf_detach(&attach);
+err_free:
+	free(tmp);
+	return err;
+}
+
+/**
+ * Register an externally-allocated CUDA range with the given registry.
+ *
+ * Walks the alloc_granularity-aligned chunks intersecting [vaddr, vaddr +
+ * nbytes), ref-bumps existing entries and populates new ones via
+ * cuMemGetHandleForAddressRange. Repeated registrations whose floored ranges
+ * overlap reuse the cached dma-buf and resolve to identical phys.
+ *
+ * `vaddr` and `nbytes` may have arbitrary byte alignment; the chunk cache
+ * resolves at byte granularity. Note that downstream consumers may impose
+ * stricter alignment, e.g., NVMe PRP construction requires host-page-aligned
+ * buffer addresses (asserted in nvme_request_prep_command_prps_*_cuda_mapped).
+ *
+ * `config` must describe the same device the registry was initialized with;
+ * it is consulted only to populate new chunks (host page size for the
+ * dma-buf LUT and granularity for the CUDA handle range). It is not retained.
+ *
+ * If non-NULL, `*out` is set to the newly-allocated registration node on
+ * success.
+ *
+ * NOTE: Set up CUDA Driver (cuInit()) and CUDA Context (cuCtxCreate())
+ * before calling this function.
+ *
+ * @return 0 on success, negative errno on failure. -EINVAL if the vaddr
+ *         range exceeds the LUT's chunk_idx capacity (raise
+ *         CUDAMEM_MAPPING_VA_BITS). -EOPNOTSUPP if the BAR1 contiguity
+ *         assumption is violated for some chunk.
+ */
+static inline int
+cudamem_mapping_add(struct cudamem_mapping_registry *registry, struct cudamem_config *config,
+		    void *vaddr, size_t nbytes, struct cudamem_mapping_registration **out)
+{
+	uint64_t va;
+	size_t chunk_first, chunk_cnt, bumped_cnt = 0;
+	struct cudamem_mapping_registration *m = NULL;
+	int err;
+
+	if (!registry || !config || !vaddr || !nbytes) {
+		return -EINVAL;
+	}
+
+	const uint64_t mask = registry->gran_mask;
+	const int gran_shift = registry->gran_shift;
+
+	va = (uint64_t)vaddr;
+	chunk_first = (size_t)(va >> gran_shift);
+	chunk_cnt = (size_t)(((va & mask) + nbytes + mask) >> gran_shift);
+
+	if (chunk_first + chunk_cnt > registry->lut_capacity) {
+		UPCIE_DEBUG(
+			"FAILED: vaddr range exceeds LUT capacity; raise CUDAMEM_MAPPING_VA_BITS");
+		return -EINVAL;
+	}
+
+	m = calloc(1, sizeof(*m));
+	if (!m) {
+		return -ENOMEM;
+	}
+	m->vaddr = va;
+	m->size = nbytes;
+
+	for (size_t k = 0; k < chunk_cnt; ++k) {
+		const size_t idx = chunk_first + k;
+		struct cudamem_mapping_chunk_meta *cm = &registry->lut_meta[idx];
+
+		if (cm->rc == 0) {
+			const uint64_t chunk_va = (uint64_t)idx << gran_shift;
+			err = cudamem_mapping_chunk_populate(&registry->lut_phys[idx], &cm->attach,
+							     chunk_va, config);
+			if (err) {
+				goto err_unwind;
+			}
+		}
+		cm->rc++;
+		bumped_cnt++;
+	}
+
+	m->next = registry->list;
+	registry->list = m;
+	if (out) {
+		*out = m;
+	}
+
+	return 0;
+
+err_unwind:
+	cudamem_mapping_chunk_deref(registry, chunk_first, bumped_cnt);
+
+	free(m);
+	return err;
+}
+
+/**
+ * Remove a registration from the registry.
+ *
+ * Finds the registration with the given vaddr in the list, decrements rc on
+ * each chunk it covered, and detaches the dma-buf for chunks whose rc
+ * reaches zero.
+ *
+ * @return 0 on success, -EINVAL if no registration with that vaddr exists.
+ */
+static inline int
+cudamem_mapping_remove(struct cudamem_mapping_registry *registry, void *vaddr)
+{
+	if (!registry) {
+		return -EINVAL;
+	}
+
+	const uint64_t key = (uint64_t)vaddr;
+	const int gran_shift = registry->gran_shift;
+	const uint64_t mask = registry->gran_mask;
+
+	for (struct cudamem_mapping_registration **prev = &registry->list, *m = registry->list; m;
+	     prev = &m->next, m = m->next) {
+		if (m->vaddr == key) {
+			const size_t chunk_first = (size_t)(m->vaddr >> gran_shift);
+			const size_t chunk_cnt =
+				(size_t)(((m->vaddr & mask) + m->size + mask) >> gran_shift);
+
+			cudamem_mapping_chunk_deref(registry, chunk_first, chunk_cnt);
+
+			*prev = m->next;
+			free(m);
+			return 0;
+		}
+	}
+
+	return -EINVAL;
+}
+
+/**
+ * Resolve a CUDA virtual address registered with the registry.
+ *
+ * O(1): one LUT load.
+ *
+ * @return 0 on success, -EINVAL if `virt` is not in a registered chunk.
+ */
+static inline int
+cudamem_mapping_virt_to_phys(struct cudamem_mapping_registry *registry, void *virt, uint64_t *phys)
+{
+	if (!registry || !virt || !phys) {
+		return -EINVAL;
+	}
+
+	const uint64_t va = (uint64_t)virt;
+	const int gran_shift = registry->gran_shift;
+	const uint64_t mask = registry->gran_mask;
+	const size_t idx = (size_t)(va >> gran_shift);
+	uint64_t base;
+
+	if (idx >= registry->lut_capacity) {
+		return -EINVAL;
+	}
+
+	base = registry->lut_phys[idx];
+	if (base == 0) {
+		return -EINVAL;
+	}
+
+	*phys = base + (va & mask);
+	return 0;
+}

--- a/include/upcie/nvme/nvme_request_cuda.h
+++ b/include/upcie/nvme/nvme_request_cuda.h
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
-
 /**
  * CUDA NVMe Request Extension
  * ===========================
@@ -31,9 +30,11 @@
  */
 static inline void
 nvme_request_prep_command_prps_contig_cuda(struct nvme_request *request, struct cudamem_heap *heap,
-                                           void *dbuf, size_t dbuf_nbytes, struct nvme_command *cmd)
+					   void *dbuf, size_t dbuf_nbytes,
+					   struct nvme_command *cmd)
 {
-	const uint64_t npages = (dbuf_nbytes + heap->config->pagesize - 1) >> heap->config->pagesize_shift;
+	const uint64_t npages =
+		(dbuf_nbytes + heap->config->pagesize - 1) >> heap->config->pagesize_shift;
 	const uint64_t pagesize = heap->config->pagesize;
 
 	/* Chaining is not supported, thus assert that the given dbuf fits. */
@@ -76,7 +77,8 @@ nvme_request_prep_command_prps_contig_cuda(struct nvme_request *request, struct 
  */
 static inline void
 nvme_request_prep_command_prps_iov_cuda(struct nvme_request *request, struct cudamem_heap *heap,
-				   	struct iovec *dvec, size_t dvec_cnt, struct nvme_command *cmd)
+					struct iovec *dvec, size_t dvec_cnt,
+					struct nvme_command *cmd)
 {
 	const uint64_t pagesize = heap->config->pagesize;
 	uint64_t *prp_list = (uint64_t *)request->prp;
@@ -108,4 +110,146 @@ nvme_request_prep_command_prps_iov_cuda(struct nvme_request *request, struct cud
 	} else if (prp_idx > 1) {
 		cmd->prp2 = request->prp_addr;
 	}
+}
+
+/**
+ * Prepare PRPs for a contiguous CUDA data buffer registered with a mapping
+ * registry.
+ *
+ * The buffer is resolved page-by-page through the registry's chunk cache,
+ * with no contiguity assumption. This variant is for buffers registered via
+ * cudamem_mapping; heap-allocated buffers should use
+ * nvme_request_prep_command_prps_contig_cuda() instead.
+ *
+ * Caveats
+ * -------
+ *
+ * - `dbuf` must be host-page-aligned (NVMe PRP entries past PRP1 must be
+ *   page-aligned per spec); asserted.
+ * - Does *not* support PRP list chaining; only a single list page is constructed.
+ *
+ * @param request Pointer to the NVMe request context used for tracking and metadata.
+ * @param registry Mapping registry to resolve through.
+ * @param config Device memory config (for host page size).
+ * @param dbuf Pointer to the contiguous data buffer to be described by PRPs.
+ * @param dbuf_nbytes Size in bytes of the data buffer.
+ * @param cmd Pointer to the NVMe command to be prepared with PRP entries.
+ * @return 0 on success, -EINVAL if any page of the buffer is unmapped.
+ */
+static inline int
+nvme_request_prep_command_prps_contig_cuda_mapped(struct nvme_request *request,
+						  struct cudamem_mapping_registry *registry,
+						  struct cudamem_config *config, void *dbuf,
+						  size_t dbuf_nbytes, struct nvme_command *cmd)
+{
+	const uint64_t pagesize = config->pagesize;
+	const uint64_t pagesize_shift = config->pagesize_shift;
+	const size_t prp_cap = pagesize / sizeof(uint64_t);
+	const uint64_t npages = (dbuf_nbytes + pagesize - 1) >> pagesize_shift;
+	int err;
+
+	assert(((uintptr_t)dbuf & (pagesize - 1)) == 0);
+
+	if (npages > 1 + prp_cap) {
+		return -EINVAL;
+	}
+
+	err = cudamem_mapping_virt_to_phys(registry, dbuf, &cmd->prp1);
+	if (err) {
+		return err;
+	}
+
+	if (npages == 1) {
+		return 0;
+	}
+	if (npages == 2) {
+		return cudamem_mapping_virt_to_phys(registry, (uint8_t *)dbuf + pagesize,
+						    &cmd->prp2);
+	}
+
+	uint64_t *prp_list = (uint64_t *)request->prp;
+	cmd->prp2 = request->prp_addr;
+	for (uint64_t i = 1; i < npages; ++i) {
+		err = cudamem_mapping_virt_to_phys(
+			registry, (uint8_t *)dbuf + (i << pagesize_shift), &prp_list[i - 1]);
+		if (err) {
+			return err;
+		}
+	}
+	return 0;
+}
+
+/**
+ * Prepare PRPs for a CUDA iovec (scatter-gather) data buffer registered with
+ * a mapping registry.
+ *
+ * Each entry is resolved page-by-page through the registry's chunk cache.
+ * This variant is for iovecs registered via cudamem_mapping; heap-allocated
+ * iovecs should use nvme_request_prep_command_prps_iov_cuda() instead.
+ *
+ * Each `dvec[i].iov_base` must be host-page-aligned (every PRP-list entry
+ * must be page-aligned per NVMe spec); asserted.
+ *
+ * @param request Pointer to the NVMe request context used for tracking and metadata.
+ * @param registry Mapping registry to resolve through.
+ * @param config Device memory config (for host page size).
+ * @param dvec Array of iovec structures describing the data segments.
+ * @param dvec_cnt Number of elements in the dvec array.
+ * @param cmd Pointer to the NVMe command to be prepared with PRP entries.
+ * @return 0 on success, -EINVAL if any iovec cannot be resolved.
+ */
+static inline int
+nvme_request_prep_command_prps_iov_cuda_mapped(struct nvme_request *request,
+					       struct cudamem_mapping_registry *registry,
+					       struct cudamem_config *config, struct iovec *dvec,
+					       size_t dvec_cnt, struct nvme_command *cmd)
+{
+	if (dvec_cnt == 0) {
+		return -EINVAL;
+	}
+
+	const uint64_t pagesize = config->pagesize;
+	const size_t prp_cap = pagesize / sizeof(uint64_t);
+	uint64_t *prp_list = (uint64_t *)request->prp;
+	size_t prp_idx = 0;
+	int err;
+
+	for (size_t i = 0; i < dvec_cnt; ++i) {
+		uint8_t *base = (uint8_t *)dvec[i].iov_base;
+		size_t iov_len = dvec[i].iov_len;
+		size_t offset = 0;
+		size_t remaining = iov_len;
+
+		assert(((uintptr_t)base & (pagesize - 1)) == 0);
+
+		if (i == 0) {
+			err = cudamem_mapping_virt_to_phys(registry, base, &cmd->prp1);
+			if (err) {
+				return err;
+			}
+			offset = pagesize;
+			remaining = (remaining > pagesize) ? remaining - pagesize : 0;
+		}
+
+		while (remaining > 0) {
+			if (prp_idx >= prp_cap) {
+				return -EINVAL;
+			}
+			err = cudamem_mapping_virt_to_phys(registry, base + offset,
+							   &prp_list[prp_idx++]);
+			if (err) {
+				return err;
+			}
+			offset += pagesize;
+			remaining = (remaining > pagesize) ? remaining - pagesize : 0;
+		}
+	}
+
+	if (prp_idx == 1) {
+		cmd->prp2 = prp_list[0];
+	} else if (prp_idx > 1) {
+		cmd->prp2 = request->prp_addr;
+	}
+
+	return 0;
 }

--- a/include/upcie/nvme/nvme_request_cuda.h
+++ b/include/upcie/nvme/nvme_request_cuda.h
@@ -115,3 +115,146 @@ nvme_request_prep_command_prps_iov_cuda(struct nvme_request *request, struct cud
 		cmd->prp2 = request->prp_addr;
 	}
 }
+
+/**
+ * Prepare PRPs for a contiguous CUDA data buffer registered with a mapping
+ * registry.
+ *
+ * The buffer is resolved page-by-page through the registry's chunk cache,
+ * with no contiguity assumption. This variant is for buffers registered via
+ * cudamem_mapping; heap-allocated buffers should use
+ * nvme_request_prep_command_prps_contig_cuda() instead.
+ *
+ * Caveats
+ * -------
+ *
+ * - Only PRP1 may carry a sub-page offset; the page count and every later
+ *   entry are resolved from the page floor (entries past PRP1 must be
+ *   page-aligned per spec).
+ * - Does *not* support PRP list chaining; only a single list page is constructed.
+ *
+ * @param request Pointer to the NVMe request context used for tracking and metadata.
+ * @param registry Mapping registry to resolve through.
+ * @param config Device memory config (for host page size).
+ * @param dbuf Pointer to the contiguous data buffer to be described by PRPs.
+ * @param dbuf_nbytes Size in bytes of the data buffer.
+ * @param cmd Pointer to the NVMe command to be prepared with PRP entries.
+ * @return 0 on success, -EINVAL if any page of the buffer is unmapped.
+ */
+static inline int
+nvme_request_prep_command_prps_contig_cuda_mapped(struct nvme_request *request,
+						  struct cudamem_mapping_registry *registry,
+						  struct cudamem_config *config, void *dbuf,
+						  size_t dbuf_nbytes, struct nvme_command *cmd)
+{
+	const uint64_t pagesize = config->pagesize;
+	const uint64_t pagesize_shift = config->pagesize_shift;
+	const size_t prp_cap = pagesize / sizeof(uint64_t);
+	const uint64_t page_off = (uintptr_t)dbuf & (pagesize - 1);
+	uint8_t *page_base = (uint8_t *)dbuf - page_off;
+	const uint64_t npages = (page_off + dbuf_nbytes + pagesize - 1) >> pagesize_shift;
+	int err;
+
+	if (npages > 1 + prp_cap) {
+		return -EINVAL;
+	}
+
+	/* virt_to_phys preserves the sub-page offset, so PRP1 carries it. */
+	err = cudamem_mapping_virt_to_phys(registry, dbuf, &cmd->prp1);
+	if (err) {
+		return err;
+	}
+
+	if (npages == 1) {
+		return 0;
+	}
+	if (npages == 2) {
+		return cudamem_mapping_virt_to_phys(registry, page_base + pagesize, &cmd->prp2);
+	}
+
+	uint64_t *prp_list = (uint64_t *)request->prp;
+	cmd->prp2 = request->prp_addr;
+	for (uint64_t i = 1; i < npages; ++i) {
+		err = cudamem_mapping_virt_to_phys(registry, page_base + (i << pagesize_shift),
+						   &prp_list[i - 1]);
+		if (err) {
+			return err;
+		}
+	}
+	return 0;
+}
+
+/**
+ * Prepare PRPs for a CUDA iovec (scatter-gather) data buffer registered with
+ * a mapping registry.
+ *
+ * Each entry is resolved page-by-page through the registry's chunk cache.
+ * This variant is for iovecs registered via cudamem_mapping; heap-allocated
+ * iovecs should use nvme_request_prep_command_prps_iov_cuda() instead.
+ *
+ * Each `dvec[i].iov_base` must be host-page-aligned (every PRP-list entry
+ * must be page-aligned per NVMe spec); asserted.
+ *
+ * @param request Pointer to the NVMe request context used for tracking and metadata.
+ * @param registry Mapping registry to resolve through.
+ * @param config Device memory config (for host page size).
+ * @param dvec Array of iovec structures describing the data segments.
+ * @param dvec_cnt Number of elements in the dvec array.
+ * @param cmd Pointer to the NVMe command to be prepared with PRP entries.
+ * @return 0 on success, -EINVAL if any iovec cannot be resolved.
+ */
+static inline int
+nvme_request_prep_command_prps_iov_cuda_mapped(struct nvme_request *request,
+					       struct cudamem_mapping_registry *registry,
+					       struct cudamem_config *config, struct iovec *dvec,
+					       size_t dvec_cnt, struct nvme_command *cmd)
+{
+	if (dvec_cnt == 0) {
+		return -EINVAL;
+	}
+
+	const uint64_t pagesize = config->pagesize;
+	const size_t prp_cap = pagesize / sizeof(uint64_t);
+	uint64_t *prp_list = (uint64_t *)request->prp;
+	size_t prp_idx = 0;
+	int err;
+
+	for (size_t i = 0; i < dvec_cnt; ++i) {
+		uint8_t *base = (uint8_t *)dvec[i].iov_base;
+		size_t iov_len = dvec[i].iov_len;
+		size_t offset = 0;
+		size_t remaining = iov_len;
+
+		assert(((uintptr_t)base & (pagesize - 1)) == 0);
+
+		if (i == 0) {
+			err = cudamem_mapping_virt_to_phys(registry, base, &cmd->prp1);
+			if (err) {
+				return err;
+			}
+			offset = pagesize;
+			remaining = (remaining > pagesize) ? remaining - pagesize : 0;
+		}
+
+		while (remaining > 0) {
+			if (prp_idx >= prp_cap) {
+				return -EINVAL;
+			}
+			err = cudamem_mapping_virt_to_phys(registry, base + offset,
+							   &prp_list[prp_idx++]);
+			if (err) {
+				return err;
+			}
+			offset += pagesize;
+			remaining = (remaining > pagesize) ? remaining - pagesize : 0;
+		}
+	}
+
+	if (prp_idx == 1) {
+		cmd->prp2 = prp_list[0];
+	} else if (prp_idx > 1) {
+		cmd->prp2 = request->prp_addr;
+	}
+
+	return 0;
+}

--- a/include/upcie/pci.h
+++ b/include/upcie/pci.h
@@ -249,6 +249,36 @@ pci_bar_unmap(struct pci_func_bar *bar)
 	return 0;
 }
 
+/**
+ * Read the size of PCI BAR `id` for the function at `bdf` from sysfs, without
+ * mapping it. Useful for verifying BAR sizing before mapping or for callers
+ * that only need the size (e.g. to check BAR1 vs device memory size).
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static inline int
+pci_bar_size(const char *bdf, uint8_t id, size_t *size)
+{
+	struct stat barstat = {0};
+	char path[256] = {0};
+	int err;
+
+	if (!bdf || !size) {
+		return -EINVAL;
+	}
+
+	snprintf(path, sizeof(path), "/sys/bus/pci/devices/%.*s/resource%" PRIu8, PCI_BDF_LEN, bdf,
+		 id);
+
+	err = stat(path, &barstat);
+	if (err) {
+		return -errno;
+	}
+
+	*size = (size_t)barstat.st_size;
+	return 0;
+}
+
 static inline int
 pci_bar_map(const char *bdf, uint8_t id, struct pci_func_bar *bar)
 {

--- a/include/upcie/upcie_cuda.h
+++ b/include/upcie/upcie_cuda.h
@@ -26,6 +26,7 @@ extern "C" {
 #include <upcie/cudamem_config.h>
 #include <upcie/cudamem_heap.h>
 #include <upcie/cudamem_dma.h>
+#include <upcie/cudamem_mapping.h>
 
 // CUDA uPCIe NVMe libraries
 #ifdef _UPCIE_WITH_NVME

--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,7 @@ install_headers(
     'include/upcie/cudamem_config.h',
     'include/upcie/cudamem_dma.h',
     'include/upcie/cudamem_heap.h',
+    'include/upcie/cudamem_mapping.h',
     'include/upcie/dmabuf.h',
     'include/upcie/hostmem_config.h',
     'include/upcie/hostmem_dma.h',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -25,6 +25,7 @@ endforeach
 cutest_sources = files(
   'test_cudamem_heap.c',
   'test_cudamem_dmabuf.c',
+  'test_cudamem_mapping.c',
   'test_cudamem_nvme_readwrite.c',
   'test_cudamem_mapping_nvme_readwrite.c',
 )

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -26,6 +26,7 @@ endforeach
 cutest_sources = files(
   'test_cudamem_heap.c',
   'test_cudamem_dmabuf.c',
+  'test_cudamem_mapping.c',
   'test_cudamem_nvme_readwrite.c',
   'test_cudamem_mapping_nvme_readwrite.c',
 )

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -26,6 +26,7 @@ cutest_sources = files(
   'test_cudamem_heap.c',
   'test_cudamem_dmabuf.c',
   'test_cudamem_nvme_readwrite.c',
+  'test_cudamem_mapping_nvme_readwrite.c',
 )
 
 # Tests depending on linking with CUDA and compiled CUDA kernels

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -27,6 +27,7 @@ cutest_sources = files(
   'test_cudamem_heap.c',
   'test_cudamem_dmabuf.c',
   'test_cudamem_nvme_readwrite.c',
+  'test_cudamem_mapping_nvme_readwrite.c',
 )
 
 # Tests depending on linking with CUDA and compiled CUDA kernels

--- a/tests/test_cudamem_mapping.c
+++ b/tests/test_cudamem_mapping.c
@@ -1,0 +1,595 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <upcie/upcie_cuda.h>
+#include <cuda.h>
+
+#define EXPECT_EQ(label, got, want)                                                      \
+	do {                                                                             \
+		long long _g = (long long)(got);                                         \
+		long long _w = (long long)(want);                                        \
+		if (_g != _w) {                                                          \
+			printf("# FAILED: %s; got(%lld) want(%lld)\n", (label), _g, _w); \
+			return 1;                                                        \
+		}                                                                        \
+	} while (0)
+
+static int
+test_add_remove_clear(struct cudamem_mapping_registry *registry, struct cudamem_config *config)
+{
+	const size_t page = (size_t)config->device_pagesize;
+	const size_t nbytes = 4 * page;
+	CUdeviceptr raw = 0;
+	void *aligned = NULL;
+	size_t aligned_nbytes = 0;
+	uint64_t phys = 0;
+	int err;
+
+	printf("# test_add_remove_clear\n");
+
+	err = (cuMemAlloc(&raw, nbytes) == CUDA_SUCCESS) ? 0 : -ENOMEM;
+	EXPECT_EQ("cuMemAlloc", err, 0);
+	aligned = (void *)raw;
+	aligned_nbytes = nbytes;
+
+	err = cudamem_mapping_add(registry, config, aligned, aligned_nbytes, NULL);
+	EXPECT_EQ("cudamem_mapping_add", err, 0);
+
+	err = cudamem_mapping_virt_to_phys(registry, aligned, &phys);
+	EXPECT_EQ("virt_to_phys(base)", err, 0);
+	if (phys == 0) {
+		printf("# FAILED: phys is zero\n");
+		return 1;
+	}
+
+	err = cudamem_mapping_remove(registry, aligned);
+	EXPECT_EQ("cudamem_mapping_remove", err, 0);
+
+	err = cudamem_mapping_virt_to_phys(registry, aligned, &phys);
+	EXPECT_EQ("virt_to_phys(after remove)", err, -EINVAL);
+
+	err = cudamem_mapping_add(registry, config, aligned, aligned_nbytes, NULL);
+	EXPECT_EQ("cudamem_mapping_add(re-add)", err, 0);
+
+	cudamem_mapping_clear(registry);
+	if (registry->list != NULL) {
+		printf("# FAILED: registry->list non-NULL after clear\n");
+		return 1;
+	}
+
+	cuMemFree(raw);
+	return 0;
+}
+
+static int
+test_unaligned_lookup(struct cudamem_mapping_registry *registry, struct cudamem_config *config)
+{
+	const size_t page = (size_t)config->device_pagesize;
+	const size_t nbytes = 4 * page;
+	CUdeviceptr raw = 0;
+	void *aligned = NULL;
+	size_t aligned_nbytes = 0;
+	uint64_t base_phys = 0, off_phys = 0;
+	const uint64_t in_page_offset = 1234;
+	const uint64_t cross_page_offset = page + 4321;
+	int err;
+
+	printf("# test_unaligned_lookup\n");
+
+	err = (cuMemAlloc(&raw, nbytes) == CUDA_SUCCESS) ? 0 : -ENOMEM;
+	EXPECT_EQ("cuMemAlloc", err, 0);
+	aligned = (void *)raw;
+	aligned_nbytes = nbytes;
+
+	err = cudamem_mapping_add(registry, config, aligned, aligned_nbytes, NULL);
+	EXPECT_EQ("cudamem_mapping_add", err, 0);
+
+	err = cudamem_mapping_virt_to_phys(registry, aligned, &base_phys);
+	EXPECT_EQ("virt_to_phys(base)", err, 0);
+
+	/* Unaligned VA inside the first page must resolve to base_phys + offset. */
+	err = cudamem_mapping_virt_to_phys(registry, (uint8_t *)aligned + in_page_offset,
+					   &off_phys);
+	EXPECT_EQ("virt_to_phys(in-page offset)", err, 0);
+	if (off_phys != base_phys + in_page_offset) {
+		printf("# FAILED: in-page offset mismatch; got(0x%" PRIx64 ") want(0x%" PRIx64
+		       ")\n",
+		       off_phys, base_phys + in_page_offset);
+		return 1;
+	}
+
+	/* Unaligned VA in a later page resolves through a different LUT slot;
+	 * within-page offset must still be added. */
+	uint64_t page2_base = 0;
+	err = cudamem_mapping_virt_to_phys(registry, (uint8_t *)aligned + page, &page2_base);
+	EXPECT_EQ("virt_to_phys(page2 base)", err, 0);
+
+	err = cudamem_mapping_virt_to_phys(registry, (uint8_t *)aligned + cross_page_offset,
+					   &off_phys);
+	EXPECT_EQ("virt_to_phys(cross-page offset)", err, 0);
+	if (off_phys != page2_base + (cross_page_offset - page)) {
+		printf("# FAILED: cross-page offset mismatch; got(0x%" PRIx64 ") want(0x%" PRIx64
+		       ")\n",
+		       off_phys, page2_base + (cross_page_offset - page));
+		return 1;
+	}
+
+	cudamem_mapping_clear(registry);
+	cuMemFree(raw);
+	return 0;
+}
+
+static int
+test_arbitrary_alignment(struct cudamem_mapping_registry *registry, struct cudamem_config *config)
+{
+	const size_t host_page = (size_t)config->pagesize;
+	const size_t dev_page = (size_t)config->device_pagesize;
+	const size_t nbytes = 4 * dev_page;
+	CUdeviceptr raw = 0;
+	void *aligned = NULL;
+	size_t aligned_nbytes = 0;
+	int err;
+
+	printf("# test_arbitrary_alignment\n");
+
+	err = (cuMemAlloc(&raw, nbytes) == CUDA_SUCCESS) ? 0 : -ENOMEM;
+	EXPECT_EQ("cuMemAlloc", err, 0);
+	aligned = (void *)raw;
+	aligned_nbytes = nbytes;
+
+	/* Sub-host-page vaddr: accepted (chunk cache resolves at byte granularity). */
+	err = cudamem_mapping_add(registry, config, (uint8_t *)aligned + 1, aligned_nbytes, NULL);
+	EXPECT_EQ("add(sub-host-page vaddr)", err, 0);
+	cudamem_mapping_clear(registry);
+
+	/* Sub-host-page size: accepted. */
+	err = cudamem_mapping_add(registry, config, aligned, aligned_nbytes - 1, NULL);
+	EXPECT_EQ("add(sub-host-page size)", err, 0);
+	cudamem_mapping_clear(registry);
+
+	/* Host-page aligned but sub-device-page aligned: accepted. */
+	err = cudamem_mapping_add(registry, config, (uint8_t *)aligned + host_page,
+				  aligned_nbytes - 2 * host_page, NULL);
+	EXPECT_EQ("add(host-page aligned, sub-device-page)", err, 0);
+
+	cudamem_mapping_clear(registry);
+	cuMemFree(raw);
+	return 0;
+}
+
+/* A 64-byte cuMemAlloc occupies only a fraction of its chunk, but the chunk
+ * itself is fully VA-reserved. _add must export at chunk granularity, not at
+ * the user's tight size, so registration of a sub-pagesize allocation
+ * succeeds. */
+static int
+test_subpage_alloc(struct cudamem_mapping_registry *registry, struct cudamem_config *config)
+{
+	CUdeviceptr raw = 0;
+	uint64_t phys = 0;
+	int err;
+
+	printf("# test_subpage_alloc\n");
+
+	err = (cuMemAlloc(&raw, 64) == CUDA_SUCCESS) ? 0 : -ENOMEM;
+	EXPECT_EQ("cuMemAlloc(64)", err, 0);
+
+	err = cudamem_mapping_add(registry, config, (void *)raw, 64, NULL);
+	EXPECT_EQ("add(64-byte buffer)", err, 0);
+
+	err = cudamem_mapping_virt_to_phys(registry, (void *)raw, &phys);
+	EXPECT_EQ("virt_to_phys(64-byte buffer)", err, 0);
+	if (phys == 0) {
+		printf("# FAILED: phys is zero\n");
+		return 1;
+	}
+
+	cudamem_mapping_clear(registry);
+	cuMemFree(raw);
+	return 0;
+}
+
+static int
+test_lookup_unmapped(struct cudamem_mapping_registry *registry, struct cudamem_config *config)
+{
+	const size_t page = (size_t)config->device_pagesize;
+	const size_t gran = config->alloc_granularity;
+	const size_t nbytes = 2 * page;
+	CUdeviceptr raw = 0;
+	void *aligned = NULL;
+	size_t aligned_nbytes = 0;
+	uint64_t phys = 0;
+	int err;
+
+	printf("# test_lookup_unmapped\n");
+
+	err = (cuMemAlloc(&raw, nbytes) == CUDA_SUCCESS) ? 0 : -ENOMEM;
+	EXPECT_EQ("cuMemAlloc", err, 0);
+	aligned = (void *)raw;
+	aligned_nbytes = nbytes;
+
+	err = cudamem_mapping_add(registry, config, aligned, aligned_nbytes, NULL);
+	EXPECT_EQ("cudamem_mapping_add", err, 0);
+
+	/* One chunk below the registered range; expected unmapped. */
+	err = cudamem_mapping_virt_to_phys(registry, (void *)((uint64_t)aligned - gran), &phys);
+	EXPECT_EQ("virt_to_phys(chunk below registered)", err, -EINVAL);
+
+	/* One chunk above the registered range; expected unmapped. */
+	err = cudamem_mapping_virt_to_phys(registry, (uint8_t *)aligned + gran, &phys);
+	EXPECT_EQ("virt_to_phys(chunk above registered)", err, -EINVAL);
+
+	cudamem_mapping_clear(registry);
+	cuMemFree(raw);
+	return 0;
+}
+
+static int
+test_multiple_mappings(struct cudamem_mapping_registry *registry, struct cudamem_config *config)
+{
+	const size_t gran = config->alloc_granularity;
+	CUdeviceptr raw[3] = {0};
+	void *aligned[3] = {0};
+	size_t aligned_nbytes[3] = {0};
+	uint64_t phys = 0;
+	int err;
+
+	printf("# test_multiple_mappings\n");
+
+	/* Allocate gran bytes per mapping so each lands in (typically) its own
+	 * chunk. Smaller per-allocation sizes get packed into a single chunk,
+	 * which would cause the middle remove to leave the chunk live and
+	 * allow the supposedly-removed mapping to still resolve. */
+	for (int i = 0; i < 3; i++) {
+		err = (cuMemAlloc(&raw[i], gran) == CUDA_SUCCESS) ? 0 : -ENOMEM;
+		EXPECT_EQ("cuMemAlloc", err, 0);
+		aligned[i] = (void *)raw[i];
+		aligned_nbytes[i] = gran;
+
+		err = cudamem_mapping_add(registry, config, aligned[i], aligned_nbytes[i], NULL);
+		EXPECT_EQ("cudamem_mapping_add", err, 0);
+	}
+
+	for (int i = 0; i < 3; i++) {
+		err = cudamem_mapping_virt_to_phys(registry, aligned[i], &phys);
+		EXPECT_EQ("virt_to_phys", err, 0);
+		if (phys == 0) {
+			printf("# FAILED: phys is zero for mapping %d\n", i);
+			return 1;
+		}
+	}
+
+	/* Remove the middle one and verify the other two still resolve. */
+	err = cudamem_mapping_remove(registry, aligned[1]);
+	EXPECT_EQ("cudamem_mapping_remove(middle)", err, 0);
+
+	err = cudamem_mapping_virt_to_phys(registry, aligned[1], &phys);
+	EXPECT_EQ("virt_to_phys(after remove middle)", err, -EINVAL);
+
+	err = cudamem_mapping_virt_to_phys(registry, aligned[0], &phys);
+	EXPECT_EQ("virt_to_phys(0 still mapped)", err, 0);
+
+	err = cudamem_mapping_virt_to_phys(registry, aligned[2], &phys);
+	EXPECT_EQ("virt_to_phys(2 still mapped)", err, 0);
+
+	cudamem_mapping_clear(registry);
+	for (int i = 0; i < 3; i++) {
+		cuMemFree(raw[i]);
+	}
+	return 0;
+}
+
+static int
+test_descending_order_registration(struct cudamem_mapping_registry *registry,
+				   struct cudamem_config *config)
+{
+	/* Register three distinct chunks in descending vaddr order. The LUT is
+	 * indexed by absolute chunk_idx, so registration order should not
+	 * affect resolution. Use gran-sized allocations to ensure each lands
+	 * in a distinct chunk. */
+	const size_t gran = config->alloc_granularity;
+	CUdeviceptr raw[3] = {0};
+	void *aligned[3] = {0};
+	size_t aligned_nbytes[3] = {0};
+	uint64_t phys = 0;
+	int err;
+
+	printf("# test_descending_order_registration\n");
+
+	for (int i = 0; i < 3; i++) {
+		err = (cuMemAlloc(&raw[i], gran) == CUDA_SUCCESS) ? 0 : -ENOMEM;
+		EXPECT_EQ("cuMemAlloc", err, 0);
+		aligned[i] = (void *)raw[i];
+		aligned_nbytes[i] = gran;
+	}
+
+	/* Sort indices by vaddr descending so we register the highest first. */
+	int order[3] = {0, 1, 2};
+	for (int i = 0; i < 3; i++) {
+		for (int j = i + 1; j < 3; j++) {
+			if ((uint64_t)aligned[order[i]] < (uint64_t)aligned[order[j]]) {
+				int tmp = order[i];
+				order[i] = order[j];
+				order[j] = tmp;
+			}
+		}
+	}
+
+	for (int i = 0; i < 3; i++) {
+		err = cudamem_mapping_add(registry, config, aligned[order[i]],
+					  aligned_nbytes[order[i]], NULL);
+		EXPECT_EQ("cudamem_mapping_add", err, 0);
+	}
+
+	for (int i = 0; i < 3; i++) {
+		err = cudamem_mapping_virt_to_phys(registry, aligned[i], &phys);
+		EXPECT_EQ("virt_to_phys", err, 0);
+		if (phys == 0) {
+			printf("# FAILED: phys is zero for mapping %d\n", i);
+			return 1;
+		}
+	}
+
+	cudamem_mapping_clear(registry);
+	for (int i = 0; i < 3; i++) {
+		cuMemFree(raw[i]);
+	}
+	return 0;
+}
+
+static int
+test_add_host_pointer(struct cudamem_mapping_registry *registry, struct cudamem_config *config)
+{
+	const size_t page = (size_t)config->device_pagesize;
+	void *host = NULL;
+	int err;
+
+	printf("# test_add_host_pointer\n");
+
+	/* Page-aligned host pointer passes _add's alignment check, but isn't GPU
+	 * memory, so cuMemGetHandleForAddressRange must fail. Exercises the
+	 * err_free unwind path inside _add. */
+	host = aligned_alloc(page, 4 * page);
+	if (!host) {
+		printf("# FAILED: aligned_alloc; errno(%d)\n", errno);
+		return 1;
+	}
+
+	err = cudamem_mapping_add(registry, config, host, 4 * page, NULL);
+	if (err == 0) {
+		printf("# FAILED: _add(host pointer) unexpectedly succeeded\n");
+		cudamem_mapping_clear(registry);
+		free(host);
+		return 1;
+	}
+	printf("# _add(host pointer) rejected with err=%d\n", err);
+
+	/* Registry must remain consistent (empty) after the failed _add. */
+	if (registry->list != NULL) {
+		printf("# FAILED: registry->list non-NULL after failed _add\n");
+		free(host);
+		return 1;
+	}
+
+	free(host);
+	return 0;
+}
+
+/* Two registrations covering the same chunk: rc must track them, phys must
+ * match, and the chunk is only released when both are removed. Drive this
+ * via two cuMemAlloc calls of one host page each. The driver tends to pack
+ * adjacent small allocations into the same chunk, but we don't depend on
+ * that, the test self-detects whether the two allocations actually share a
+ * chunk and asserts the right invariants either way. */
+static int
+test_chunk_sharing(struct cudamem_mapping_registry *registry, struct cudamem_config *config)
+{
+	const size_t page = (size_t)config->pagesize;
+	const uint64_t mask = config->alloc_granularity - 1;
+	CUdeviceptr raw_a = 0, raw_b = 0;
+	void *a = NULL, *b = NULL;
+	size_t a_nbytes = 0, b_nbytes = 0;
+	uint64_t phys_before_a = 0, phys_before_b = 0;
+	uint64_t phys_after_a = 0;
+	int err;
+
+	printf("# test_chunk_sharing\n");
+
+	err = (cuMemAlloc(&raw_a, page) == CUDA_SUCCESS) ? 0 : -ENOMEM;
+	EXPECT_EQ("cuMemAlloc(a)", err, 0);
+	a = (void *)raw_a;
+	a_nbytes = page;
+	err = (cuMemAlloc(&raw_b, page) == CUDA_SUCCESS) ? 0 : -ENOMEM;
+	EXPECT_EQ("cuMemAlloc(b)", err, 0);
+	b = (void *)raw_b;
+	b_nbytes = page;
+
+	err = cudamem_mapping_add(registry, config, a, a_nbytes, NULL);
+	EXPECT_EQ("add(a)", err, 0);
+	err = cudamem_mapping_add(registry, config, b, b_nbytes, NULL);
+	EXPECT_EQ("add(b)", err, 0);
+
+	err = cudamem_mapping_virt_to_phys(registry, a, &phys_before_a);
+	EXPECT_EQ("virt_to_phys(a)", err, 0);
+	err = cudamem_mapping_virt_to_phys(registry, b, &phys_before_b);
+	EXPECT_EQ("virt_to_phys(b)", err, 0);
+
+	const int shared_chunk = (((uint64_t)a & ~mask) == ((uint64_t)b & ~mask));
+	printf("# test_chunk_sharing: a=0x%" PRIxPTR " b=0x%" PRIxPTR " shared=%s\n", (uintptr_t)a,
+	       (uintptr_t)b, shared_chunk ? "yes" : "no");
+
+	err = cudamem_mapping_remove(registry, b);
+	EXPECT_EQ("remove(b)", err, 0);
+
+	/* a still resolves with the same phys whether or not b shared its
+	 * chunk. */
+	err = cudamem_mapping_virt_to_phys(registry, a, &phys_after_a);
+	EXPECT_EQ("virt_to_phys(a after remove(b))", err, 0);
+	if (phys_after_a != phys_before_a) {
+		printf("# FAILED: phys for a changed across remove(b)\n");
+		return 1;
+	}
+
+	/* When chunks were shared, b's vaddr is still resolvable through a's
+	 * registration since the chunk is still cached. When not shared, b's
+	 * chunk is now released and resolution must fail. */
+	uint64_t phys_b_after_remove = 0;
+	int b_after_err = cudamem_mapping_virt_to_phys(registry, b, &phys_b_after_remove);
+	if (shared_chunk) {
+		EXPECT_EQ("virt_to_phys(b after remove(b), shared chunk)", b_after_err, 0);
+		if (phys_b_after_remove != phys_before_b) {
+			printf("# FAILED: phys for b inside still-cached chunk drifted\n");
+			return 1;
+		}
+	} else {
+		EXPECT_EQ("virt_to_phys(b after remove(b), distinct chunk)", b_after_err, -EINVAL);
+	}
+
+	cudamem_mapping_clear(registry);
+	cuMemFree(raw_a);
+	cuMemFree(raw_b);
+	return 0;
+}
+
+/* Registration that crosses a chunk boundary must populate every chunk it
+ * touches, and the per-page virt_to_phys must produce contiguous phys
+ * across the boundary so PRP construction works for buffers larger than a
+ * single chunk. */
+static int
+test_cross_chunk_mapping(struct cudamem_mapping_registry *registry, struct cudamem_config *config)
+{
+	const size_t page = (size_t)config->pagesize;
+	const size_t gran = config->alloc_granularity;
+	CUdeviceptr raw = 0;
+	void *aligned = NULL;
+	size_t aligned_nbytes = 0;
+	int err;
+
+	printf("# test_cross_chunk_mapping\n");
+
+	/* Allocate >gran bytes to span at least two chunks regardless of where
+	 * cuMemAlloc places the start. */
+	const size_t alloc_nbytes = gran + 16 * page;
+	err = (cuMemAlloc(&raw, alloc_nbytes) == CUDA_SUCCESS) ? 0 : -ENOMEM;
+	EXPECT_EQ("cuMemAlloc", err, 0);
+	aligned = (void *)raw;
+	aligned_nbytes = alloc_nbytes;
+
+	err = cudamem_mapping_add(registry, config, aligned, aligned_nbytes, NULL);
+	EXPECT_EQ("cudamem_mapping_add", err, 0);
+
+	const size_t npages = aligned_nbytes / page;
+	uint64_t prev_phys = 0;
+	for (size_t i = 0; i < npages; ++i) {
+		uint64_t phys = 0;
+		err = cudamem_mapping_virt_to_phys(registry, (uint8_t *)aligned + i * page, &phys);
+		EXPECT_EQ("virt_to_phys per-page", err, 0);
+		if (i > 0 && phys != prev_phys + page) {
+			/* Adjacent pages within a chunk are contiguous in phys
+			 * (probe 12). The boundary between chunks is not
+			 * required to be contiguous, since each chunk is its
+			 * own BAR1 IOVA window. */
+			const uintptr_t va = (uintptr_t)aligned + i * page;
+			const uintptr_t prev_va = va - page;
+			const int crossing_chunk_boundary = (va & ~((uintptr_t)gran - 1)) !=
+							    (prev_va & ~((uintptr_t)gran - 1));
+			if (!crossing_chunk_boundary) {
+				printf("# FAILED: phys discontinuity within chunk at page %zu\n",
+				       i);
+				return 1;
+			}
+		}
+		prev_phys = phys;
+	}
+
+	cudamem_mapping_clear(registry);
+	cuMemFree(raw);
+	return 0;
+}
+
+int
+main(void)
+{
+	struct cudamem_config config = {0};
+	struct cudamem_mapping_registry registry = {0};
+	CUdevice cu_dev;
+	CUcontext cu_ctx;
+	int err;
+
+	err = cuInit(0);
+	if (err) {
+		printf("# FAILED: cuInit(); err(%d)\n", err);
+		return err;
+	}
+
+	err = cuDeviceGet(&cu_dev, 0);
+	if (err) {
+		printf("# FAILED: cuDeviceGet(); err(%d)\n", err);
+		return err;
+	}
+
+	err = cuCtxCreate(&cu_ctx, 0, cu_dev);
+	if (err) {
+		printf("# FAILED: cuCtxCreate(); err(%d)\n", err);
+		return err;
+	}
+
+	err = cudamem_config_init(&config, 0);
+	if (err) {
+		printf("# FAILED: cudamem_config_init(); err(%d)\n", err);
+		goto exit_ctx;
+	}
+
+	err = cudamem_mapping_registry_init(&registry, &config);
+	if (err) {
+		printf("# FAILED: cudamem_mapping_registry_init(); err(%d)\n", err);
+		goto exit_ctx;
+	}
+
+	err = test_add_remove_clear(&registry, &config);
+	if (err) {
+		goto exit;
+	}
+	err = test_unaligned_lookup(&registry, &config);
+	if (err) {
+		goto exit;
+	}
+	err = test_arbitrary_alignment(&registry, &config);
+	if (err) {
+		goto exit;
+	}
+	err = test_subpage_alloc(&registry, &config);
+	if (err) {
+		goto exit;
+	}
+	err = test_lookup_unmapped(&registry, &config);
+	if (err) {
+		goto exit;
+	}
+	err = test_multiple_mappings(&registry, &config);
+	if (err) {
+		goto exit;
+	}
+	err = test_descending_order_registration(&registry, &config);
+	if (err) {
+		goto exit;
+	}
+	err = test_add_host_pointer(&registry, &config);
+	if (err) {
+		goto exit;
+	}
+	err = test_chunk_sharing(&registry, &config);
+	if (err) {
+		goto exit;
+	}
+	err = test_cross_chunk_mapping(&registry, &config);
+	if (err) {
+		goto exit;
+	}
+
+	printf("SUCCES: all cudamem_mapping tests passed\n");
+
+exit:
+	cudamem_mapping_registry_term(&registry);
+exit_ctx:
+	cuCtxDestroy(cu_ctx);
+	return err;
+}

--- a/tests/test_cudamem_mapping_nvme_readwrite.c
+++ b/tests/test_cudamem_mapping_nvme_readwrite.c
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define _UPCIE_WITH_NVME
+#include <upcie/upcie_cuda.h>
+
+struct rte {
+	struct hostmem_config config;
+	struct hostmem_heap heap;
+	struct cudamem_config cuda_config;
+	CUcontext cu_ctx;
+};
+
+struct nvme {
+	struct nvme_controller ctrlr;
+	struct nvme_qpair ioq;
+};
+
+int
+rte_init(struct rte *rte)
+{
+	CUdevice cu_dev;
+	int err;
+
+	err = hostmem_config_init(&rte->config);
+	if (err) {
+		printf("FAILED: hostmem_config_init(); err(%d)\n", err);
+		return err;
+	}
+
+	err = hostmem_heap_init(&rte->heap, 1024 * 1024 * 128ULL, &rte->config);
+	if (err) {
+		printf("FAILED: hostmem_heap_init(); err(%d)\n", err);
+		return err;
+	}
+
+	err = cuInit(0);
+	if (err) {
+		printf("FAILED: cuInit(); err(%d)\n", err);
+		return err;
+	}
+
+	err = cuDeviceGet(&cu_dev, 0); // GPU ID 0
+	if (err) {
+		printf("FAILED: cuDeviceGet(); err(%d)\n", err);
+		return err;
+	}
+
+	err = cuCtxCreate(&rte->cu_ctx, 0, cu_dev);
+	if (err) {
+		printf("FAILED: cuCtxCreate(); err(%d)\n", err);
+		return err;
+	}
+
+	err = cudamem_config_init(&rte->cuda_config, 0);
+	if (err) {
+		printf("FAILED: cudamem_config_init(); err(%d)\n", err);
+		return err;
+	}
+
+	return 0;
+}
+
+int
+nvme_io(struct nvme *nvme, struct cudamem_mapping_registry *registry,
+	struct cudamem_config *cuda_config, uint8_t opc, void *buffer, size_t buffer_size)
+{
+	struct nvme_completion cpl = {0};
+	struct nvme_command cmd = {0};
+	struct nvme_request *req;
+	uint8_t sc, sct;
+	int err;
+
+	req = nvme_request_alloc(nvme->ioq.rpool);
+	if (!req) {
+		err = errno;
+		printf("FAILED: nvme_request_alloc(); err(%d)\n", err);
+		return err;
+	}
+	cmd.cid = req->cid;
+	cmd.nsid = 1;
+	cmd.opc = opc;
+	cmd.cdw10 = 0; ///< SLBA == 0
+	cmd.cdw12 = 0; ///< NLB == 0
+
+	err = nvme_request_prep_command_prps_contig_cuda_mapped(req, registry, cuda_config, buffer,
+								buffer_size, &cmd);
+	if (err) {
+		printf("FAILED: prps_contig_cuda_mapped(); err(%d)\n", err);
+		return err;
+	}
+
+	err = nvme_qpair_enqueue(&nvme->ioq, &cmd);
+	if (err) {
+		printf("FAILED: nvme_qpair_enqueue(); err(%d)\n", err);
+		return err;
+	}
+
+	nvme_qpair_sqdb_update(&nvme->ioq);
+
+	err = nvme_qpair_reap_cpl(&nvme->ioq, nvme->ctrlr.timeout_ms, &cpl);
+	if (err) {
+		printf("FAILED: nvme_qpair_reap_cpl(); err(%d)\n", err);
+		return err;
+	}
+
+	nvme_request_free(nvme->ioq.rpool, cpl.cid);
+
+	sc = (cpl.status & 0x1FE) >> 1;
+	sct = (cpl.status & 0xE00) >> 8;
+	if (sc) {
+		printf("FAILED: Status Code Type(0x%x), Status Code(0x%x)\n", sct, sc);
+		err = EIO;
+	}
+
+	return err;
+}
+
+int
+nvme_init(struct nvme *nvme, const char *bdf, struct rte *rte)
+{
+	struct nvme_completion cpl = {0};
+	struct nvme_command cmd = {0};
+	int err;
+
+	err = nvme_controller_open(&nvme->ctrlr, bdf, &rte->heap);
+	if (err) {
+		printf("FAILED: nvme_device_open(); err(%d)\n", err);
+		return err;
+	}
+
+	cmd.opc = 0x6; ///< IDENTIFY
+	cmd.cdw10 = 1; // CNS=1: Identify Controller
+
+	err = nvme_qpair_submit_sync_contig_prps(&nvme->ctrlr.aq, nvme->ctrlr.heap,
+						 nvme->ctrlr.buf, 4096, &cmd,
+						 nvme->ctrlr.timeout_ms, &cpl);
+	if (err) {
+		printf("FAILED: nvme_qpair_submit_sync(); err(%d)\n", err);
+		nvme_controller_close(&nvme->ctrlr);
+		return err;
+	}
+
+	err = nvme_controller_create_io_qpair(&nvme->ctrlr, &nvme->ioq, 32);
+	if (err) {
+		printf("FAILED: nvme_device_create_io_qpair(); err(%d)\n", err);
+		return err;
+	}
+
+	return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+	struct nvme nvme = {0};
+	struct rte rte = {0};
+	struct cudamem_mapping_registry registry = {0};
+	const size_t buffer_size = 82 * sizeof(char);
+	size_t mapping_size;
+	CUdeviceptr raw_write = 0, raw_read = 0;
+	void *write_buf = NULL, *read_buf = NULL; ///< CUDA IO buffers
+	char *expected = NULL, *actual = NULL;    ///< HOST buffers for comparison
+	int err;
+
+	if (argc != 2) {
+		printf("Usage: %s <PCI-BDF>\n", argv[0]);
+		return 1;
+	}
+
+	err = rte_init(&rte);
+	if (err) {
+		printf("FAILED: rte_init(); err(%d)\n", err);
+		return err;
+	}
+
+	err = nvme_init(&nvme, argv[1], &rte);
+	if (err) {
+		printf("FAILED: nvme_init(); err(%d)\n", err);
+		return err;
+	}
+
+	err = cudamem_mapping_registry_init(&registry, &rte.cuda_config);
+	if (err) {
+		printf("FAILED: cudamem_mapping_registry_init(); err(%d)\n", err);
+		goto exit;
+	}
+
+	mapping_size = rte.cuda_config.pagesize;
+
+	err = (cuMemAlloc(&raw_write, mapping_size) == CUDA_SUCCESS) ? 0 : -ENOMEM;
+	if (err) {
+		printf("FAILED: cuMemAlloc(write); err(%d)\n", err);
+		goto exit;
+	}
+	write_buf = (void *)raw_write;
+
+	err = (cuMemAlloc(&raw_read, mapping_size) == CUDA_SUCCESS) ? 0 : -ENOMEM;
+	if (err) {
+		printf("FAILED: cuMemAlloc(read); err(%d)\n", err);
+		goto exit;
+	}
+	read_buf = (void *)raw_read;
+
+	err = cudamem_mapping_add(&registry, &rte.cuda_config, write_buf, mapping_size, NULL);
+	if (err) {
+		printf("FAILED: cudamem_mapping_add(write); err(%d)\n", err);
+		goto exit;
+	}
+
+	err = cudamem_mapping_add(&registry, &rte.cuda_config, read_buf, mapping_size, NULL);
+	if (err) {
+		printf("FAILED: cudamem_mapping_add(read); err(%d)\n", err);
+		goto exit;
+	}
+
+	expected = malloc(buffer_size);
+	if (!expected) {
+		err = errno;
+		printf("FAILED: malloc(expected); err(%d)\n", err);
+		goto exit;
+	}
+
+	actual = malloc(buffer_size);
+	if (!actual) {
+		err = errno;
+		printf("FAILED: malloc(actual); err(%d)\n", err);
+		goto exit;
+	}
+
+	// Fill buffer with ascii characters
+	for (size_t i = 0; i < buffer_size; i++) {
+		expected[i] = (i % 26) + 65;
+	}
+
+	memset(actual, 0, buffer_size);
+
+	err = cuMemcpyHtoD((CUdeviceptr)write_buf, expected, buffer_size);
+	if (err) {
+		printf("FAILED: cuMemcpyHtoD(expected -> write_buf); err(%d)\n", err);
+		goto exit;
+	}
+
+	err = cuMemcpyHtoD((CUdeviceptr)read_buf, actual, buffer_size);
+	if (err) {
+		printf("FAILED: cuMemcpyHtoD(actual -> read_buf); err(%d)\n", err);
+		goto exit;
+	}
+
+	err = nvme_io(&nvme, &registry, &rte.cuda_config, 0x1, write_buf, buffer_size);
+	if (err) {
+		printf("FAILED: nvme_io(write); err(%d)\n", err);
+		goto exit;
+	}
+
+	err = nvme_io(&nvme, &registry, &rte.cuda_config, 0x2, read_buf, buffer_size);
+	if (err) {
+		printf("FAILED: nvme_io(read); err(%d)\n", err);
+		goto exit;
+	}
+
+	err = cuMemcpyDtoH(actual, (CUdeviceptr)read_buf, buffer_size);
+	if (err) {
+		printf("FAILED: cuMemcpyDtoH(read_buf -> actual); err(%d)\n", err);
+		goto exit;
+	}
+
+	for (size_t i = 0; i < buffer_size; i++) {
+		if (expected[i] != actual[i]) {
+			printf("FAILED: written data != read data\n");
+			printf("Wrote: %s\n", expected);
+			printf("Read: %s\n", actual);
+			goto exit;
+		}
+	}
+	printf("SUCCES: written data == read data\n");
+
+exit:
+	cudamem_mapping_registry_term(&registry);
+	if (raw_write) {
+		cuMemFree(raw_write);
+	}
+	if (raw_read) {
+		cuMemFree(raw_read);
+	}
+	free(expected);
+	free(actual);
+	nvme_controller_close(&nvme.ctrlr);
+	hostmem_heap_term(&rte.heap);
+	cuCtxDestroy(rte.cu_ctx);
+
+	return err;
+}


### PR DESCRIPTION
Used by https://github.com/xnvme/xnvme/pull/663.

The new file `include/upcie/cudamem_mapping.h` calls `cuMemGetHandleForAddressRange` to obtain a dma-buf fd for the registered range, attaches it, and builds a physical address LUT at device_pagesize granularity stored in a new cudamem_mapping entry on a per-runtime linked list. mem_unmap detaches the dma-buf and removes the entry. _cuda_rte_term drains any mappings still alive when the last controller is closed.

Each upcie-cuda command path dispatches on the heap range at the call site: heap buffers go to the upstream nvme_request_prep_command_prps_{contig,iov}_cuda (renamed to _cuda_heap), while mapped buffers go through the new _mapped variants which resolve page-by-page through the mapping's phys_lut with explicit bounds checks. A resolution failure on a mapped buffer is reported as -EINVAL.

vaddr and nbytes passed to mem_map must be aligned to device_pagesize. Unaligned inputs return -EINVAL. mem_unmap matches by the exact vaddr that was passed to mem_map.

