### PR TITLE
fix(nvme): enable bus mastering for VFIO devices

### DIFF
--- a/include/upcie/nvme/nvme_controller_vfio.h
+++ b/include/upcie/nvme/nvme_controller_vfio.h
@@ -13,6 +13,36 @@ struct vfio_ctx {
 	int iommu_set;
 };
 
+static inline int
+nvme_vfio_pci_bus_master_enable(int device_fd)
+{
+	struct vfio_region_info config = {0};
+	uint16_t cmd;
+	ssize_t ret;
+	int err;
+
+	config.index = VFIO_PCI_CONFIG_REGION_INDEX;
+	err = vfio_device_get_region_info(device_fd, &config);
+	if (err < 0) {
+		return -errno;
+	}
+
+	ret = pread(device_fd, &cmd, sizeof(cmd), config.offset + PCI_COMMAND);
+	if (ret != (ssize_t)sizeof(cmd)) {
+		return ret < 0 ? -errno : -EIO;
+	}
+
+	if (!(cmd & PCI_COMMAND_MASTER)) {
+		cmd |= PCI_COMMAND_MASTER;
+		ret = pwrite(device_fd, &cmd, sizeof(cmd), config.offset + PCI_COMMAND);
+		if (ret != (ssize_t)sizeof(cmd)) {
+			return ret < 0 ? -errno : -EIO;
+		}
+	}
+
+	return 0;
+}
+
 static inline void
 nvme_vfio_ctx_init(struct vfio_ctx *vfio)
 {
@@ -273,6 +303,12 @@ nvme_controller_open_vfio(struct nvme_controller *ctrlr, struct vfio_ctx *vfio, 
 	if (vfio->device_fd < 0) {
 		err = -errno;
 		UPCIE_DEBUG("FAILED: vfio_group_get_device_fd(); errno(%d)", errno);
+		goto fail;
+	}
+
+	err = nvme_vfio_pci_bus_master_enable(vfio->device_fd);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_vfio_pci_bus_master_enable(); err(%d)", err);
 		goto fail;
 	}
 

--- a/include/upcie/upcie.h
+++ b/include/upcie/upcie.h
@@ -63,6 +63,7 @@ extern "C" {
 
 // Linux UAPI
 #include <linux/memfd.h>
+#include <linux/pci_regs.h>
 #include <linux/vfio.h>
 
 // uPCIe libraries

--- a/include/upcie/vfioctl.h
+++ b/include/upcie/vfioctl.h
@@ -175,8 +175,11 @@ vfio_device_get_info(int device_fd, struct vfio_device_info *info)
 static inline int
 vfio_device_get_region_info(int device_fd, struct vfio_region_info *region)
 {
+	__u32 index = region->index;
+
 	memset(region, 0, sizeof(*region));
 	region->argsz = sizeof(*region);
+	region->index = index;
 
 	return ioctl(device_fd, VFIO_DEVICE_GET_REGION_INFO, region);
 }


### PR DESCRIPTION
VFIO may clear the PCI command bus master bit while opening a device fd. MMIO still works in that state, but the controller cannot DMA admin completions back to host memory.

Read the VFIO PCI config region after opening the device and enable bus mastering before mapping BAR0 and starting controller setup. Use the Linux PCI register definitions for the command register offset and bus master bit.

Fix vfio_device_get_region_info() to preserve the caller-provided region index while initializing the ioctl payload, so non-BAR0 regions such as PCI config space are queried correctly.