### PR TITLE
fix(nvme): account for buffer offset in PRP page count

### DIFF
--- a/include/upcie/nvme/nvme_request.h
+++ b/include/upcie/nvme/nvme_request.h
@@ -174,25 +174,30 @@ static inline void
 nvme_request_prep_command_prps_contig(struct nvme_request *request, struct hostmem_heap *heap,
 				      void *dbuf, size_t dbuf_nbytes, struct nvme_command *cmd)
 {
-	const uint64_t npages = (dbuf_nbytes + heap->config->pagesize - 1) >> heap->config->pagesize_shift;
 	const uint64_t pagesize = heap->config->pagesize;
+
+	cmd->prp1 = hostmem_dma_v2p(heap, dbuf);
+
+	/* Only PRP1 may carry a sub-page offset; the page count and every later
+	 * entry are measured from the page floor. ceil((off+nbytes)/pagesize). */
+	const uint64_t page_off = cmd->prp1 & (pagesize - 1);
+	const uint64_t page_base = cmd->prp1 - page_off;
+	const uint64_t npages =
+		(page_off + dbuf_nbytes + pagesize - 1) >> heap->config->pagesize_shift;
 
 	/* Chaining is not supported, thus assert that the given dbuf fits. */
 	assert(npages <= 1 + 512);
 
-	cmd->prp1 = hostmem_dma_v2p(heap, dbuf);
-
 	if (npages == 1) {
 		return;
 	} else if (npages == 2) {
-		cmd->prp2 = hostmem_dma_v2p(heap, dbuf + pagesize);
+		cmd->prp2 = page_base + pagesize;
 	} else {
 		uint64_t *prp_list = request->prp;
 
 		cmd->prp2 = request->prp_addr;
 		for (uint64_t i = 1; i < npages; ++i) {
-
-			prp_list[i - 1] = cmd->prp1 + (i << heap->config->pagesize_shift);
+			prp_list[i - 1] = page_base + (i << heap->config->pagesize_shift);
 		}
 	}
 }

--- a/include/upcie/nvme/nvme_request_cuda.h
+++ b/include/upcie/nvme/nvme_request_cuda.h
@@ -33,24 +33,30 @@ static inline void
 nvme_request_prep_command_prps_contig_cuda(struct nvme_request *request, struct cudamem_heap *heap,
                                            void *dbuf, size_t dbuf_nbytes, struct nvme_command *cmd)
 {
-	const uint64_t npages = (dbuf_nbytes + heap->config->pagesize - 1) >> heap->config->pagesize_shift;
 	const uint64_t pagesize = heap->config->pagesize;
+
+	cmd->prp1 = cudamem_heap_block_vtp(heap, dbuf);
+
+	/* Only PRP1 may carry a sub-page offset; the page count and every later
+	 * entry are measured from the page floor. ceil((off+nbytes)/pagesize). */
+	const uint64_t page_off = cmd->prp1 & (pagesize - 1);
+	const uint64_t page_base = cmd->prp1 - page_off;
+	const uint64_t npages =
+		(page_off + dbuf_nbytes + pagesize - 1) >> heap->config->pagesize_shift;
 
 	/* Chaining is not supported, thus assert that the given dbuf fits. */
 	assert(npages <= 1 + 512);
 
-	cmd->prp1 = cudamem_heap_block_vtp(heap, dbuf);
-
 	if (npages == 1) {
 		return;
 	} else if (npages == 2) {
-		cmd->prp2 = cmd->prp1 + pagesize;
+		cmd->prp2 = page_base + pagesize;
 	} else {
 		uint64_t *prp_list = (uint64_t *)request->prp;
 
 		cmd->prp2 = request->prp_addr;
 		for (uint64_t i = 1; i < npages; ++i) {
-			prp_list[i - 1] = cmd->prp1 + (i << heap->config->pagesize_shift);
+			prp_list[i - 1] = page_base + (i << heap->config->pagesize_shift);
 		}
 	}
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -7,6 +7,7 @@ test_sources = files(
   'test_pci_scan.c',
   'test_hostmem_dmabuf.c',
   'test_hostmem_nvme_readwrite.c',
+  'test_hostmem_nvme_read_offset.c',
 )
 
 incdir = include_directories('../include')

--- a/tests/test_hostmem_nvme_read_offset.c
+++ b/tests/test_hostmem_nvme_read_offset.c
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Tests that nvme_request_prep_command_prps_contig
+// (include/upcie/nvme/nvme_request.h) describes a buffer correctly when it
+// starts at a sub-page offset within its page.
+//
+// Contract: reading an LBA range into a buffer at any offset must succeed and
+// return the same bytes as reading the same range into a page-aligned buffer.
+// Only PRP1 carries the offset; the page count and every entry past PRP1 follow
+// from the page floor, so buffers whose offset pushes the transfer across a
+// page boundary are the cases worth exercising.
+//
+// Each case reads twice, once into a page-aligned buffer (ground truth) and
+// once into a buffer at the given offset, and asserts both succeed and return
+// identical bytes. Read-only: the namespace is never written.
+
+#define _UPCIE_WITH_NVME
+#include <upcie/upcie.h>
+
+#define PAGESIZE 4096u
+#define LBA_SIZE 512u // swissknife Samsung 990 PRO, LBA format 0
+
+struct nvme {
+	struct nvme_controller ctrlr;
+	struct nvme_qpair ioq;
+};
+
+// page_off is the buffer's offset within its first page; nbytes must be a
+// multiple of LBA_SIZE.
+static const struct {
+	uint64_t page_off;
+	size_t nbytes;
+} cases[] = {
+	{0, 2u * PAGESIZE},    // aligned baseline: spans exactly two pages
+	{512, PAGESIZE},       // offset pushes a one-page length onto a second page
+	{512, 2u * PAGESIZE},  // offset spans three pages: PRP1, then two list entries
+	{2048, 2u * PAGESIZE}, // mid-page offset spanning three pages
+	{3584, 2u * PAGESIZE}, // deep offset: PRP1 carries 512 B, remainder page-aligned
+};
+
+static int
+read_lbas(struct nvme *nvme, void *dbuf, size_t nbytes, uint64_t slba, uint8_t *sc)
+{
+	struct nvme_completion cpl = {0};
+	struct nvme_command cmd = {0};
+	struct nvme_request *req = nvme_request_alloc(nvme->ioq.rpool);
+	uint64_t nlb = (nbytes + LBA_SIZE - 1) / LBA_SIZE;
+	int err;
+
+	cmd.cid = req->cid;
+	cmd.nsid = 1;
+	cmd.opc = 0x2; // READ
+	cmd.cdw10 = (uint32_t)(slba & 0xFFFFFFFF);
+	cmd.cdw11 = (uint32_t)(slba >> 32);
+	cmd.cdw12 = (uint32_t)(nlb - 1); // NLB is 0-based
+	nvme_request_prep_command_prps_contig(req, nvme->ctrlr.heap, dbuf, nbytes, &cmd);
+
+	nvme_qpair_enqueue(&nvme->ioq, &cmd);
+	nvme_qpair_sqdb_update(&nvme->ioq);
+	err = nvme_qpair_reap_cpl(&nvme->ioq, nvme->ctrlr.timeout_ms, &cpl);
+	if (err)
+		return err;
+	nvme_request_free(nvme->ioq.rpool, cpl.cid);
+	*sc = (cpl.status & 0x1FE) >> 1;
+	return 0;
+}
+
+static int
+nvme_init(struct nvme *nvme, const char *bdf, struct hostmem_heap *heap)
+{
+	struct nvme_completion cpl = {0};
+	struct nvme_command cmd = {0};
+
+	if (nvme_controller_open(&nvme->ctrlr, bdf, heap))
+		return EIO;
+	cmd.opc = 0x6; // IDENTIFY, CNS=1: brings up the controller
+	cmd.cdw10 = 1;
+	if (nvme_qpair_submit_sync_contig_prps(&nvme->ctrlr.aq, nvme->ctrlr.heap, nvme->ctrlr.buf,
+					       4096, &cmd, nvme->ctrlr.timeout_ms, &cpl) ||
+	    nvme_controller_create_io_qpair(&nvme->ctrlr, &nvme->ioq, 32)) {
+		nvme_controller_close(&nvme->ctrlr);
+		return EIO;
+	}
+	return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+	struct hostmem_config config = {0};
+	struct hostmem_heap heap = {0};
+	struct nvme nvme = {0};
+	uint8_t *aligned, *offbuf;
+	uint64_t slba = (argc == 3) ? strtoull(argv[2], NULL, 0) : 2048;
+	int failures = 0, err;
+
+	if (argc < 2 || argc > 3) {
+		printf("Usage: %s <PCI-BDF> [SLBA]   (read-only)\n", argv[0]);
+		return 1;
+	}
+	if (hostmem_config_init(&config) ||
+	    hostmem_heap_init(&heap, 128ULL * 1024 * 1024, &config)) {
+		printf("FAILED: heap init\n");
+		return 1;
+	}
+	err = nvme_init(&nvme, argv[1], &heap);
+	if (err) {
+		printf("FAILED: nvme bring-up\n");
+		hostmem_heap_term(&heap);
+		return err;
+	}
+
+	// One generous allocation each; offbuf is indexed by page_off per case.
+	aligned = hostmem_dma_malloc(&heap, 8u * PAGESIZE);
+	offbuf = hostmem_dma_malloc(&heap, 8u * PAGESIZE);
+
+	for (size_t c = 0; c < sizeof(cases) / sizeof(cases[0]); c++) {
+		size_t nbytes = cases[c].nbytes;
+		uint8_t *dbuf = offbuf + cases[c].page_off;
+		uint8_t sc_a = 0, sc_o = 0;
+
+		memset(aligned, 0, 8u * PAGESIZE);
+		memset(offbuf, 0, 8u * PAGESIZE);
+
+		if (read_lbas(&nvme, aligned, nbytes, slba, &sc_a) || sc_a) {
+			printf("[off=%4llu nbytes=%5zu] FAIL: ground-truth read sc=0x%x\n",
+			       (unsigned long long)cases[c].page_off, nbytes, sc_a);
+			failures++;
+			continue;
+		}
+		if (read_lbas(&nvme, dbuf, nbytes, slba, &sc_o) || sc_o) {
+			printf("[off=%4llu nbytes=%5zu] FAIL: offset read sc=0x%x\n",
+			       (unsigned long long)cases[c].page_off, nbytes, sc_o);
+			failures++;
+			continue;
+		}
+		if (memcmp(aligned, dbuf, nbytes)) {
+			printf("[off=%4llu nbytes=%5zu] FAIL: offset data != aligned data\n",
+			       (unsigned long long)cases[c].page_off, nbytes);
+			failures++;
+			continue;
+		}
+		printf("[off=%4llu nbytes=%5zu] ok\n", (unsigned long long)cases[c].page_off,
+		       nbytes);
+	}
+
+	printf("%s: %d/%zu cases passed\n", failures ? "FAILED" : "SUCCESS",
+	       (int)(sizeof(cases) / sizeof(cases[0])) - failures,
+	       sizeof(cases) / sizeof(cases[0]));
+
+	hostmem_dma_free(&heap, offbuf);
+	hostmem_dma_free(&heap, aligned);
+	nvme_controller_close(&nvme.ctrlr);
+	hostmem_heap_term(&heap);
+	return failures ? 1 : 0;
+}


### PR DESCRIPTION
The contig PRP builders derived the page count from the byte length alone and stepped every entry from the offset data pointer. For a buffer with a sub-page offset this emitted too few, misaligned PRP entries. With more than one page remaining after PRP1, the controller must read PRP2 as a PRP List; it then walked the host bytes at that address as page pointers and scattered the transfer to arbitrary physical pages. Under iommu=off on the 990 PRO a pristine buffer's zero bytes decode to physical address 0, turning a read into a wild DMA write.

Measure the page count and every entry past PRP1 from the page floor: npages = ceil((page_off + nbytes) / pagesize), and step list/PRP2 from prp1 with the offset masked off. Only PRP1 may carry a sub-page offset. Applied to both the hostmem and CUDA contig builders.

Cost is +3 integer ALU ops per prep (one AND to extract the offset, one SUB for the page base, one ADD for the offset term in npages); no new multiply, divide, or memory access, and the list loop is unchanged.

Add a read-only regression test that compares offset reads against an aligned ground-truth read across the affected geometries.
