### PR TITLE
feat(controller): add function nvme_controller_delete_io_qpair()

### DIFF
--- a/example/upcie_nvme_driver.c
+++ b/example/upcie_nvme_driver.c
@@ -50,7 +50,7 @@ static void
 nvme_cleanup(struct nvme *nvme)
 {
 	if (nvme->ioq.rpool) {
-		nvme_qpair_term(&nvme->ioq);
+		nvme_controller_delete_io_qpair(&nvme->ctrlr, &nvme->ioq);
 		memset(&nvme->ioq, 0, sizeof(nvme->ioq));
 	}
 

--- a/include/upcie/nvme/nvme_controller.h
+++ b/include/upcie/nvme/nvme_controller.h
@@ -128,6 +128,55 @@ nvme_controller_open(struct nvme_controller *ctrlr, const char *bdf, struct host
 }
 
 /**
+ * Deletes the submission-queue and completion-queue and frees host-side resources.
+ *
+ * Sends Delete I/O SQ and Delete I/O CQ admin commands to the controller, then
+ * releases the host DMA memory and returns the queue ID to the free pool.
+ *
+ * @param ctrlr Pointer to a pre-allocated NVMe controller
+ * @param qpair Pointer to a queue-pair (from nvme_controller_create_io_qpair)
+ *
+ * @return 0 on success, negative errno on error. Resources are freed regardless.
+ */
+static inline int
+nvme_controller_delete_io_qpair(struct nvme_controller *ctrlr, struct nvme_qpair *qpair)
+{
+	uint16_t qid = qpair->qid;
+	int err;
+
+	{
+		struct nvme_command cmd = {0};
+		struct nvme_completion cpl = {0};
+
+		cmd.opc = 0x0; ///< Delete I/O Submission Queue
+		cmd.cdw10 = qid;
+
+		err = nvme_qpair_submit_sync(&ctrlr->aq, &cmd, ctrlr->timeout_ms, &cpl);
+		if (err) {
+			UPCIE_DEBUG("FAILED: nvme_qpair_submit_sync(Delete SQ); err(%d)", err);
+		}
+	}
+
+	{
+		struct nvme_command cmd = {0};
+		struct nvme_completion cpl = {0};
+
+		cmd.opc = 0x4; ///< Delete I/O Completion Queue
+		cmd.cdw10 = qid;
+
+		err = nvme_qpair_submit_sync(&ctrlr->aq, &cmd, ctrlr->timeout_ms, &cpl);
+		if (err) {
+			UPCIE_DEBUG("FAILED: nvme_qpair_submit_sync(Delete CQ); err(%d)", err);
+		}
+	}
+
+	nvme_qpair_term(qpair);
+	nvme_qid_free(ctrlr->qids, qid);
+
+	return err;
+}
+
+/**
  * Allocates a submission-queue, a completion-queue, and wraps them in the nvme_qpair struct
  */
 static inline int

--- a/include/upcie/nvme/nvme_controller_cuda.h
+++ b/include/upcie/nvme/nvme_controller_cuda.h
@@ -23,8 +23,9 @@ nvme_controller_cuda_delete_io_qpair(struct nvme_controller *ctrlr,
                                      struct nvme_qpair_cuda *qpair,
                                      struct cudamem_heap *heap)
 {
-	int err;
 	struct nvme_qpair_cuda _qpair = {0};
+	int err;
+
 	err = cuMemcpyDtoH(&_qpair, (CUdeviceptr)qpair, sizeof(_qpair));
 	if (err) {
 		UPCIE_DEBUG("FAILED: cuMemcpyDtoH(device QP -> host QP); CUresult(%d)", err);


### PR DESCRIPTION
There was missing a proper cleanup function for sending the NVMe commands to delete a queue pair. This already existed in the CUDA ctrlr path.

Also a small style-commit that just swaps the order of a struct and int initialisation and adds an empty line between variables declarations and function logic :)