### PR TITLE
fix(cudamem): detect framebuffer BAR for 64-bit BAR0 GPUs

### DIFF
--- a/include/upcie/cudamem_config.h
+++ b/include/upcie/cudamem_config.h
@@ -81,14 +81,12 @@ cudamem_config_pp(struct cudamem_config *config)
  * contiguity check in cudamem_mapping_chunk_populate (returning -EOPNOTSUPP
  * when violated) catches a hardware/driver mismatch at runtime.
  *
- * BAR1 size is read via pci_bar_size(bdf, 1, ...), where <bdf> is obtained
- * from cuDeviceGetPCIBusId(). The PCI BAR index 1 follows NVIDIA's discrete
- * GPU convention (BAR0 is 32-bit MMIO, BAR1 is the framebuffer aperture); a
- * 64-bit BAR0 layout (consuming registers 0 and 1) would shift the FB
- * aperture to resource2 and is not supported. The function fails if BAR1
- * size is smaller than total device memory: PCIe P2P DMA over the full
- * device memory range requires the BAR1 to span it, which in turn requires
- * resizable BAR (or a similarly sized fixed BAR) to be enabled in firmware.
+ * The framebuffer aperture size is read via pci_bar_largest_size(bdf, ...),
+ * where <bdf> is obtained from cuDeviceGetPCIBusId(); the largest BAR is the
+ * framebuffer aperture regardless of whether BAR0 is 32-bit or 64-bit. PCIe
+ * P2P DMA over the full device memory range requires the aperture to span it,
+ * which in turn requires resizable BAR (or a similarly sized fixed BAR) to be
+ * enabled in firmware.
  *
  * @param config  Pointer to the config struct to initialize
  * @param gpu_id  CUDA device ordinal
@@ -140,9 +138,9 @@ cudamem_config_init(struct cudamem_config *config, int gpu_id)
 		}
 	}
 
-	err = pci_bar_size(bdf, 1, &config->bar1_size);
+	err = pci_bar_largest_size(bdf, &config->bar1_size);
 	if (err) {
-		UPCIE_DEBUG("FAILED: pci_bar_size(%s, 1), err: %d", bdf, err);
+		UPCIE_DEBUG("FAILED: pci_bar_largest_size(%s), err: %d", bdf, err);
 		return err;
 	}
 

--- a/include/upcie/pci.h
+++ b/include/upcie/pci.h
@@ -279,6 +279,48 @@ pci_bar_size(const char *bdf, uint8_t id, size_t *size)
 	return 0;
 }
 
+/**
+ * Read the size of the largest PCI memory BAR for the function at `bdf`.
+ *
+ * Scans all BARs and returns the largest. Non-existent resourceN entries
+ * (unmapped BARs and the high half of a 64-bit BAR) are skipped.
+ *
+ * @return 0 on success with *size set, negative errno on failure.
+ */
+static inline int
+pci_bar_largest_size(const char *bdf, size_t *size)
+{
+	size_t largest = 0;
+	int found = 0;
+
+	if (!bdf || !size) {
+		return -EINVAL;
+	}
+
+	for (uint8_t id = 0; id < PCI_NBARS; ++id) {
+		size_t bar = 0;
+		int err = pci_bar_size(bdf, id, &bar);
+
+		if (err == -ENOENT) {
+			continue; // unmapped BAR, or high half of a 64-bit BAR
+		}
+		if (err) {
+			return err;
+		}
+		found = 1;
+		if (bar > largest) {
+			largest = bar;
+		}
+	}
+
+	if (!found) {
+		return -ENOENT;
+	}
+
+	*size = largest;
+	return 0;
+}
+
 static inline int
 pci_bar_map(const char *bdf, uint8_t id, struct pci_func_bar *bar)
 {


### PR DESCRIPTION
cudamem_config_init hardcoded pci_bar_size(bdf, 1, ...) for the GPU framebuffer aperture, assuming NVIDIA's "BAR0 = 32-bit MMIO, BAR1 = framebuffer" layout. On GPUs with a 64-bit BAR0 (e.g. H100 PCIe) BAR0 consumes register slots 0 and 1, shifting the framebuffer aperture to resource2; resource1 does not exist, so opening the device failed immediately with errno -2 (ENOENT).

Add pci_bar_largest_size(), which scans all BARs and returns the largest -- always the framebuffer aperture on a GPU, and the region PCIe P2P DMA must span -- and use it instead of a fixed index. Handles both 32-bit and 64-bit BAR0 layouts.