### PR TITLE
feat(dmamem): dma-buf constructor + NVMe DMA into GPU VRAM

### DIFF
--- a/cijoe/configs/hw-example.toml
+++ b/cijoe/configs/hw-example.toml
@@ -42,3 +42,11 @@ path = "{{ local.env.HOME }}/git/upcie"
 # The device under test: the target's spare NVMe.
 [upcie.dut]
 nvme_bdf = "0000:01:00.0"
+
+# Optional GPU peer used by the NVMe -> VRAM smoketests. Point at any
+# vfio-pci-capable GPU on the target; set bar_size to the actual BAR
+# size (larger with ReBAR on).
+[upcie.peer_gpu]
+bdf = "0000:02:00.0"
+bar_index = 0
+bar_size = "0x40000000"

--- a/cijoe/tasks/dmamem_nvme_vram_smoketest.yaml
+++ b/cijoe/tasks/dmamem_nvme_vram_smoketest.yaml
@@ -1,0 +1,23 @@
+---
+doc: |
+  End-to-end NVMe -> GPU VRAM DMA proof via a shared iommufd IOAS.
+
+  Binds both the NVMe controller (config.upcie.dut.nvme_bdf) and the
+  GPU peer (config.upcie.peer_gpu.bdf) to vfio-pci, resolves their
+  vfio cdev paths, and runs the smoketest. Under the hood: both
+  attach to a single iommufd IOAS, the GPU BAR is imported as a
+  dmamem via VFIO_DEVICE_FEATURE_DMA_BUF + IOMMU_IOAS_MAP_FILE, an
+  admin IDENTIFY CONTROLLER lands the 4 KiB response in VRAM, then
+  an IO qpair issues NVME_CMD_WRITE of a VRAM offset to LBA 0 (the
+  device reads GPU memory over PCIe), verified by reading LBA 0 back
+  into host memory.
+
+steps:
+- name: bind_nvme
+  run: 'devbind --device {{ config.upcie.dut.nvme_bdf }} --bind vfio-pci'
+
+- name: bind_gpu_group
+  run: 'gpu={{ config.upcie.peer_gpu.bdf }}; for bdf in $(ls /sys/bus/pci/devices/${gpu}/iommu_group/devices/); do cls=$(cat /sys/bus/pci/devices/$bdf/class 2>/dev/null); case "$cls" in 0x06*) continue;; esac; cur=$(basename $(readlink /sys/bus/pci/devices/$bdf/driver 2>/dev/null) 2>/dev/null); [ "$cur" = "vfio-pci" ] && continue; [ -n "$cur" ] && echo $bdf > /sys/bus/pci/devices/$bdf/driver/unbind; echo vfio-pci > /sys/bus/pci/devices/$bdf/driver_override; echo $bdf > /sys/bus/pci/drivers/vfio-pci/bind; done; ls /sys/bus/pci/devices/{{ config.upcie.dut.nvme_bdf }}/vfio-dev/; ls /sys/bus/pci/devices/${gpu}/vfio-dev/'
+
+- name: smoketest
+  run: '/tmp/upcie_source/builddir/tests/test_dmamem_nvme_vram "/dev/vfio/devices/$(ls /sys/bus/pci/devices/{{ config.upcie.dut.nvme_bdf }}/vfio-dev/ | head -1)" "/dev/vfio/devices/$(ls /sys/bus/pci/devices/{{ config.upcie.peer_gpu.bdf }}/vfio-dev/ | head -1)" {{ config.upcie.peer_gpu.bar_index }} {{ config.upcie.peer_gpu.bar_size }}'

--- a/cijoe/tasks/dmamem_vfio_bar_smoketest.yaml
+++ b/cijoe/tasks/dmamem_vfio_bar_smoketest.yaml
@@ -1,0 +1,15 @@
+---
+doc: |
+  Prove the mainline dma-buf-through-iommufd path: use
+  VFIO_DEVICE_FEATURE_DMA_BUF on an already-vfio-pci-bound device,
+  feed the resulting dma-buf to IOMMU_IOAS_MAP_FILE. Success confirms
+  the vfio-pci exporter path is what Linux 6.19 accepts. Runs against
+  the target NVMe from config.upcie.dut.nvme_bdf; BAR0 with a 16 KiB
+  slice.
+
+steps:
+- name: bind
+  run: 'devbind --device {{ config.upcie.dut.nvme_bdf }} --bind vfio-pci; ls /sys/bus/pci/devices/{{ config.upcie.dut.nvme_bdf }}/vfio-dev/'
+
+- name: smoketest
+  run: '/tmp/upcie_source/builddir/tests/test_dmamem_vfio_bar "/dev/vfio/devices/$(ls /sys/bus/pci/devices/{{ config.upcie.dut.nvme_bdf }}/vfio-dev/ | head -1)" 0 0x4000'

--- a/include/upcie/dmamem.h
+++ b/include/upcie/dmamem.h
@@ -32,10 +32,18 @@
  * features (dma-buf import, dirty tracking, PASID) land and is the
  * target for the rest of the design.
  *
- * Constructors:
+ * Two constructor shapes:
  *
  *   dmamem_from_memfd(...) in dmamem_memfd.h creates a hugepage-backed
  *   memfd internally and imports it into an IOAS.
+ *
+ *   dmamem_from_dmabuf(...) in dmamem_dmabuf.h imports an existing
+ *   dma-buf fd from any exporter. Producers of dma-buf fds live in the
+ *   exporter's home header: for vfio-pci-bound devices the producer is
+ *   vfio_device_bar_export_dmabuf() in vfioctl.h; the CUDA/HIP/libdrm
+ *   producer functions are the vendor runtimes' own dma-buf export APIs
+ *   and land as dmamem_from_dmabuf callers when mainline iommufd
+ *   ungates non-vfio-pci exporters.
  *
  * dmamem_destroy() unmaps and releases in every case.
  *

--- a/include/upcie/dmamem_dmabuf.h
+++ b/include/upcie/dmamem_dmabuf.h
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * dmamem constructor: from an existing dma-buf fd
+ * ===============================================
+ *
+ * Takes a dma-buf fd from any exporter (udmabuf host memory, CUDA VMM,
+ * HIP, libdrm/PRIME, VFIO_DEVICE_FEATURE_DMA_BUF) and imports it into an
+ * iommufd IOAS via IOMMU_IOAS_MAP_FILE. This is the entry point that
+ * answers the "does iommufd's MAP_FILE accept dma-buf-backed fds today?"
+ * question against a running kernel; a failure at the ioctl surfaces the
+ * exact errno so the block (kernel-side, exporter-side, or IOAS
+ * configuration) resolves to a concrete signal.
+ *
+ * The dmamem takes ownership of the dma-buf fd on success and closes it
+ * as part of dmamem_destroy. On failure the caller retains ownership and
+ * must close the fd itself.
+ *
+ * Whether the resulting dmamem exposes a CPU VA is up to the exporter.
+ * udmabuf-backed dma-bufs are CPU-mappable; VRAM-backed dma-bufs from the
+ * GPU runtimes usually are not. If mmap on the dma-buf fd fails we leave
+ * cpu_va NULL and rely on offset-based access.
+ *
+ * @file dmamem_dmabuf.h
+ * @version 0.5.1
+ */
+
+/**
+ * Import an existing dma-buf fd into the handle's IOAS as a dmamem.
+ *
+ * @param dmem       Pre-allocated dmamem descriptor to fill.
+ * @param iommufd    Open iommufd handle with an allocated IOAS (caller-owned).
+ * @param dmabuf_fd  Open dma-buf fd from any exporter.
+ * @param size       Size of the range to map.
+ *
+ * @return 0 on success (dmamem now owns dmabuf_fd), negative errno on
+ * error (caller retains dmabuf_fd).
+ */
+static inline int
+dmamem_from_dmabuf(struct dmamem *dmem, struct iommufd *iommufd, int dmabuf_fd, size_t size)
+{
+	void *cpu_va;
+	int err;
+
+	if (!dmem || !iommufd || iommufd->fd < 0 || dmabuf_fd < 0 || !size) {
+		return -EINVAL;
+	}
+
+	memset(dmem, 0, sizeof(*dmem));
+	dmem->fd = dmabuf_fd;
+	dmem->iommufd = iommufd;
+	dmem->size = size;
+	dmem->backing = DMAMEM_BACKING_DMABUF;
+
+	/*
+	 * CPU-mappability is exporter-dependent. Try mmap; leave cpu_va
+	 * NULL on failure. This is diagnostic, not fatal.
+	 */
+	cpu_va = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, dmabuf_fd, 0);
+	if (cpu_va != MAP_FAILED) {
+		dmem->cpu_va = cpu_va;
+	}
+
+	err = iommufd_ioas_map_file(iommufd, dmabuf_fd, 0, size,
+				    IOMMU_IOAS_MAP_READABLE | IOMMU_IOAS_MAP_WRITEABLE,
+				    &dmem->base_iova);
+	if (err) {
+		UPCIE_DEBUG("FAILED: iommufd_ioas_map_file(dma-buf); err(%d)", err);
+		if (dmem->cpu_va) {
+			munmap(dmem->cpu_va, size);
+			dmem->cpu_va = NULL;
+		}
+		memset(dmem, 0, sizeof(*dmem));
+		dmem->fd = -1;
+		return err;
+	}
+
+	return 0;
+}

--- a/include/upcie/nvme/nvme_controller_dmamem_vfio.h
+++ b/include/upcie/nvme/nvme_controller_dmamem_vfio.h
@@ -390,3 +390,150 @@ nvme_controller_close_dmamem_vfio(struct nvme_controller *ctrlr, struct nvme_dma
 
 	return first_err;
 }
+
+/**
+ * Synchronous admin-command helper for the dmamem admin queue.
+ *
+ * The dmamem admin queue does not carry a request pool, so submit_sync
+ * cannot be used. This helper does a manual enqueue + doorbell + reap
+ * with a caller-supplied CID.
+ */
+static inline int
+nvme_admin_sync_dmamem(struct nvme_controller *ctrlr, struct nvme_command *cmd, uint16_t cid,
+		       struct nvme_completion *cpl)
+{
+	int err;
+
+	cmd->cid = cid;
+
+	err = nvme_qpair_enqueue(&ctrlr->aq, cmd);
+	if (err) {
+		return err;
+	}
+	nvme_qpair_sqdb_update(&ctrlr->aq);
+
+	err = nvme_qpair_reap_cpl(&ctrlr->aq, ctrlr->timeout_ms, cpl);
+	if (err) {
+		return err;
+	}
+	if ((cpl->status >> 1) & 0x7FF) {
+		UPCIE_DEBUG("FAILED: admin CQE status=0x%x", cpl->status);
+		return -EIO;
+	}
+	return 0;
+}
+
+/**
+ * Create an I/O queue pair on the dmamem path.
+ *
+ * Allocates SQ/CQ from the caller's dmamem_heap, then programs the
+ * controller via admin CREATE_IO_CQ + CREATE_IO_SQ so the controller
+ * knows about the new qpair. The resulting nvme_qpair is compatible
+ * with the heap-agnostic submit/reap primitives (nvme_qpair_enqueue,
+ * nvme_qpair_sqdb_update, nvme_qpair_reap_cpl).
+ *
+ * The qid is allocated from the controller's bitmap; the caller must
+ * hold on to the returned sq_offset/cq_offset until
+ * nvme_controller_delete_io_qpair_dmamem is called.
+ */
+static inline int
+nvme_controller_create_io_qpair_dmamem(struct nvme_controller *ctrlr, struct nvme_qpair *qp,
+				       uint16_t depth, struct dmamem_heap *heap,
+				       size_t *sq_offset_out, size_t *cq_offset_out)
+{
+	struct nvme_command cmd = {0};
+	struct nvme_completion cpl = {0};
+	uint64_t sq_iova = 0, cq_iova = 0;
+	uint16_t qid;
+	int err;
+
+	err = nvme_qid_find_free(ctrlr->qids);
+	if (err < 1) {
+		return -ENOMEM;
+	}
+	qid = err;
+
+	err = nvme_qid_alloc(ctrlr->qids, qid);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_qid_alloc; err(%d)", err);
+		return err;
+	}
+
+	err = nvme_qpair_dmamem_init(qp, qid, depth, ctrlr->func.bars[0].region, heap, sq_offset_out,
+				     cq_offset_out, &sq_iova, &cq_iova);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_qpair_dmamem_init(io); err(%d)", err);
+		nvme_qid_free(ctrlr->qids, qid);
+		return err;
+	}
+
+	memset(&cmd, 0, sizeof(cmd));
+	cmd.opc = 0x5; /* Create I/O Completion Queue */
+	cmd.prp1 = cq_iova;
+	cmd.cdw10 = ((uint32_t)(depth - 1) << 16) | qid;
+	cmd.cdw11 = 0x1; /* Physically contiguous, no interrupts */
+	err = nvme_admin_sync_dmamem(ctrlr, &cmd, 2, &cpl);
+	if (err) {
+		UPCIE_DEBUG("FAILED: CREATE_IO_CQ(qid=%u); err(%d)", qid, err);
+		goto rollback_qpair;
+	}
+
+	memset(&cmd, 0, sizeof(cmd));
+	memset(&cpl, 0, sizeof(cpl));
+	cmd.opc = 0x1; /* Create I/O Submission Queue */
+	cmd.prp1 = sq_iova;
+	cmd.cdw10 = ((uint32_t)(depth - 1) << 16) | qid;
+	cmd.cdw11 = ((uint32_t)qid << 16) | 0x1; /* CQID | physically contiguous */
+	err = nvme_admin_sync_dmamem(ctrlr, &cmd, 3, &cpl);
+	if (err) {
+		struct nvme_command drop = {0};
+		struct nvme_completion drop_cpl = {0};
+
+		UPCIE_DEBUG("FAILED: CREATE_IO_SQ(qid=%u); err(%d)", qid, err);
+		drop.opc = 0x4; /* Delete I/O Completion Queue */
+		drop.cdw10 = qid;
+		(void)nvme_admin_sync_dmamem(ctrlr, &drop, 4, &drop_cpl);
+		goto rollback_qpair;
+	}
+
+	return 0;
+
+rollback_qpair:
+	nvme_qpair_dmamem_term(qp, heap, *sq_offset_out, *cq_offset_out);
+	nvme_qid_free(ctrlr->qids, qid);
+	return err;
+}
+
+/**
+ * Tear down an I/O queue pair created with the dmamem variant.
+ */
+static inline int
+nvme_controller_delete_io_qpair_dmamem(struct nvme_controller *ctrlr, struct nvme_qpair *qp,
+				       struct dmamem_heap *heap, size_t sq_offset, size_t cq_offset)
+{
+	struct nvme_command cmd = {0};
+	struct nvme_completion cpl = {0};
+	uint16_t qid = qp->qid;
+	int first_err = 0;
+	int err;
+
+	cmd.opc = 0x0; /* Delete I/O Submission Queue */
+	cmd.cdw10 = qid;
+	err = nvme_admin_sync_dmamem(ctrlr, &cmd, 5, &cpl);
+	if (err && !first_err) {
+		first_err = err;
+	}
+
+	memset(&cmd, 0, sizeof(cmd));
+	memset(&cpl, 0, sizeof(cpl));
+	cmd.opc = 0x4; /* Delete I/O Completion Queue */
+	cmd.cdw10 = qid;
+	err = nvme_admin_sync_dmamem(ctrlr, &cmd, 6, &cpl);
+	if (err && !first_err) {
+		first_err = err;
+	}
+
+	nvme_qpair_dmamem_term(qp, heap, sq_offset, cq_offset);
+	nvme_qid_free(ctrlr->qids, qid);
+	return first_err;
+}

--- a/include/upcie/upcie.h
+++ b/include/upcie/upcie.h
@@ -80,6 +80,7 @@ extern "C" {
 #include <upcie/iommufd.h>
 #include <upcie/dmamem.h>
 #include <upcie/dmamem_memfd.h>
+#include <upcie/dmamem_dmabuf.h>
 #include <upcie/dmamem_heap.h>
 #include <upcie/mmio.h>
 #include <upcie/pci.h>

--- a/include/upcie/vfioctl.h
+++ b/include/upcie/vfioctl.h
@@ -245,3 +245,73 @@ vfio_device_pci_hot_reset(struct vfio_device *dev, struct vfio_pci_hot_reset *re
 {
 	return ioctl(dev->fd, VFIO_DEVICE_PCI_HOT_RESET, reset);
 }
+
+/**
+ * Export a slice of a vfio-pci device region as a dma-buf fd.
+ *
+ * Wraps VFIO_DEVICE_FEATURE | GET | DMA_BUF. The returned fd is a
+ * regular dma-buf that iommufd's IOMMU_IOAS_MAP_FILE accepts on mainline
+ * 6.19+ because the exporter is vfio-pci (private interconnect via
+ * vfio_pci_dma_buf_iommufd_map).
+ *
+ * @param device_fd    vfio-cdev device fd (see vfio_cdev_open).
+ * @param region_index BAR/region index, e.g. VFIO_PCI_BAR1_REGION_INDEX.
+ * @param offset       Offset within the region.
+ * @param length       Length of the slice.
+ * @return dma-buf fd (>= 0) on success, negative errno on failure.
+ */
+#ifdef VFIO_DEVICE_FEATURE_DMA_BUF
+static inline int
+vfio_device_bar_export_dmabuf(int device_fd, uint32_t region_index, uint64_t offset,
+			      uint64_t length)
+{
+	size_t bufsz = sizeof(struct vfio_device_feature) +
+		       sizeof(struct vfio_device_feature_dma_buf) +
+		       sizeof(struct vfio_region_dma_range);
+	struct vfio_device_feature *feat;
+	struct vfio_device_feature_dma_buf *dbuf;
+	struct vfio_region_dma_range *range;
+	int fd_or_err;
+
+	feat = calloc(1, bufsz);
+	if (!feat) {
+		return -ENOMEM;
+	}
+
+	feat->argsz = bufsz;
+	feat->flags = VFIO_DEVICE_FEATURE_GET | VFIO_DEVICE_FEATURE_DMA_BUF;
+
+	dbuf = (struct vfio_device_feature_dma_buf *)feat->data;
+	dbuf->region_index = region_index;
+	dbuf->open_flags = O_RDWR | O_CLOEXEC;
+	dbuf->flags = 0;
+	dbuf->nr_ranges = 1;
+
+	range = &dbuf->dma_ranges[0];
+	range->offset = offset;
+	range->length = length;
+
+	fd_or_err = ioctl(device_fd, VFIO_DEVICE_FEATURE, feat);
+	if (fd_or_err < 0) {
+		fd_or_err = -errno;
+	}
+
+	free(feat);
+	return fd_or_err;
+}
+#else
+// VFIO_DEVICE_FEATURE_DMA_BUF landed in Linux 6.19; on older UAPI headers
+// this stub lets callers link and fail at runtime with a clear -ENOTSUP
+// instead of breaking the build on distros that ship an older linux/vfio.h.
+static inline int
+vfio_device_bar_export_dmabuf(int device_fd, uint32_t region_index, uint64_t offset,
+			      uint64_t length)
+{
+	(void)device_fd;
+	(void)region_index;
+	(void)offset;
+	(void)length;
+
+	return -ENOTSUP;
+}
+#endif

--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,7 @@ install_headers(
     'include/upcie/cudamem_mapping.h',
     'include/upcie/dmabuf.h',
     'include/upcie/dmamem.h',
+    'include/upcie/dmamem_dmabuf.h',
     'include/upcie/dmamem_heap.h',
     'include/upcie/dmamem_memfd.h',
     'include/upcie/hostmem_config.h',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -11,6 +11,7 @@ test_sources = files(
   'test_dmamem_memfd.c',
   'test_dmamem_nvme_identify.c',
   'test_dmamem_vfio_bar.c',
+  'test_dmamem_nvme_vram.c',
 )
 
 incdir = include_directories('../include')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -10,6 +10,7 @@ test_sources = files(
   'test_hostmem_nvme_read_offset.c',
   'test_dmamem_memfd.c',
   'test_dmamem_nvme_identify.c',
+  'test_dmamem_vfio_bar.c',
 )
 
 incdir = include_directories('../include')

--- a/tests/test_dmamem_nvme_vram.c
+++ b/tests/test_dmamem_nvme_vram.c
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * NVMe DMA into GPU VRAM via a shared iommufd IOAS (end-to-end proof)
+ * ==================================================================
+ *
+ * Attach an NVMe controller and a vfio-pci-bound GPU to the SAME iommufd
+ * IOAS, import the GPU's BAR (the VRAM window when ReBAR is on) as a
+ * dmamem via VFIO_DEVICE_FEATURE_DMA_BUF, and issue an NVMe IDENTIFY
+ * CONTROLLER whose PRP1 points into that VRAM IOVA range. The controller
+ * DMAs the 4 KiB identify response directly into GPU memory; we then peek
+ * at that VRAM offset by mmap-ing the GPU BAR through the vfio device fd
+ * and checking that the controller SN prefix landed at the expected byte
+ * position of the identify structure.
+ *
+ * On top of that IDENTIFY proof, an IO-queue-pair WRITE exercises the
+ * fragile peer direction: the controller *reads* GPU VRAM over PCIe
+ * (PRP1 in VRAM) and writes it to LBA 0, verified by reading LBA 0 back
+ * into host memory. This overwrites LBA 0 on the DUT.
+ *
+ * Usage:
+ *   test_dmamem_nvme_vram <nvme_cdev> <gpu_cdev> <gpu_bar_index> <gpu_bar_size>
+ *   e.g.
+ *   test_dmamem_nvme_vram /dev/vfio/devices/vfio0 /dev/vfio/devices/vfio1 0 0x400000000
+ */
+#define _UPCIE_WITH_NVME
+#include <upcie/upcie.h>
+
+#define IDENTIFY_OFFSET 0x2000 /* 8 KiB into VRAM, arbitrary */
+
+static int
+open_gpu_and_import_bar(struct iommufd *iommufd, const char *gpu_cdev, uint32_t bar_index,
+			uint64_t bar_size, struct vfio_cdev *dev_out, struct dmamem *bar_dmem_out,
+			void **bar_va_out, size_t *bar_va_size_out)
+{
+	struct vfio_region_info region = {0};
+	int dbuf_fd;
+	int err;
+
+	err = vfio_cdev_open(gpu_cdev, dev_out);
+	if (err) {
+		fprintf(stderr, "FAIL: vfio_cdev_open(gpu, '%s') err(%d)\n", gpu_cdev, err);
+		return err;
+	}
+
+	err = iommufd_bind(iommufd, dev_out);
+	if (err) {
+		fprintf(stderr, "FAIL: iommufd_bind(gpu) err(%d)\n", err);
+		goto err_close;
+	}
+
+	err = iommufd_attach(iommufd, dev_out);
+	if (err) {
+		fprintf(stderr, "FAIL: iommufd_attach(gpu) err(%d)\n", err);
+		goto err_close;
+	}
+
+	dbuf_fd = vfio_device_bar_export_dmabuf(dev_out->fd, bar_index, 0, bar_size);
+	if (dbuf_fd < 0) {
+		fprintf(stderr, "FAIL: vfio_device_bar_export_dmabuf(region=%u) err(%d)\n",
+			bar_index, dbuf_fd);
+		err = dbuf_fd;
+		goto err_detach;
+	}
+
+	err = dmamem_from_dmabuf(bar_dmem_out, iommufd, dbuf_fd, bar_size);
+	if (err) {
+		fprintf(stderr, "FAIL: dmamem_from_dmabuf(gpu bar) err(%d)\n", err);
+		close(dbuf_fd);
+		goto err_detach;
+	}
+
+	/* Also mmap the BAR through the vfio fd so we can CPU-verify the DMA. */
+	region.index = bar_index;
+	err = vfio_device_get_region_info(dev_out->fd, &region);
+	if (err < 0) {
+		fprintf(stderr, "FAIL: vfio_device_get_region_info(gpu) errno(%d)\n", errno);
+		err = -errno;
+		goto err_dmem;
+	}
+
+	*bar_va_size_out = region.size;
+	*bar_va_out = vfio_map_region(dev_out->fd, region.size, region.offset);
+	if (*bar_va_out == MAP_FAILED) {
+		fprintf(stderr, "FAIL: mmap gpu bar errno(%d): %s\n", errno, strerror(errno));
+		*bar_va_out = NULL;
+		err = -errno;
+		goto err_dmem;
+	}
+	return 0;
+
+err_dmem:
+	dmamem_destroy(bar_dmem_out);
+err_detach:
+	iommufd_detach(dev_out);
+err_close:
+	vfio_cdev_close(dev_out);
+	return err;
+}
+
+/*
+ * Submit a single command, ring the SQ doorbell, reap its completion, and check
+ * the CQE status. Returns 0 on success, negative errno on a submit/reap error,
+ * or -EIO on a non-zero CQE status.
+ *
+ * Used instead of nvme_qpair_submit_sync(), which allocates from qp->rpool that
+ * the dmamem qpair (nvme_qpair_dmamem_init) does not set up.
+ */
+static int
+nvme_submit_sync(struct nvme_qpair *q, struct nvme_command *cmd, uint32_t timeout_ms)
+{
+	struct nvme_completion cpl = {0};
+	int err;
+
+	err = nvme_qpair_enqueue(q, cmd);
+	if (err) {
+		return err;
+	}
+	nvme_qpair_sqdb_update(q);
+
+	err = nvme_qpair_reap_cpl(q, timeout_ms, &cpl);
+	if (err) {
+		return err;
+	}
+	if ((cpl.status >> 1) & 0x7FF) {
+		return -EIO;
+	}
+	return 0;
+}
+
+int
+main(int argc, char *argv[])
+{
+	struct iommufd iommufd = {0};
+	struct vfio_cdev gpu_dev = {0};
+	struct dmamem gpu_bar_dmem = {0};
+	struct dmamem admin_dmem = {0};
+	struct dmamem_heap admin_heap = {0};
+	struct nvme_controller ctrlr = {0};
+	struct nvme_dmamem_vfio_ctx nvme_ctx = {0};
+	struct nvme_command cmd = {0};
+	struct nvme_completion cpl = {0};
+	void *gpu_bar_va = NULL;
+	size_t gpu_bar_va_size = 0;
+	uint32_t gpu_bar_index;
+	uint64_t gpu_bar_size;
+	uint64_t identify_iova;
+	int err;
+
+	if (argc != 5) {
+		fprintf(stderr,
+			"usage: %s <nvme_cdev> <gpu_cdev> <gpu_bar_index> <gpu_bar_size>\n"
+			"  e.g. %s /dev/vfio/devices/vfio0 /dev/vfio/devices/vfio1 0 0x400000000\n",
+			argv[0], argv[0]);
+		return 2;
+	}
+	gpu_bar_index = (uint32_t)strtoul(argv[3], NULL, 0);
+	gpu_bar_size = (uint64_t)strtoull(argv[4], NULL, 0);
+
+	err = iommufd_open(&iommufd);
+	if (err) {
+		fprintf(stderr, "FAIL: iommufd_open err(%d)\n", err);
+		return 1;
+	}
+	err = iommufd_ioas_alloc(&iommufd);
+	if (err) {
+		fprintf(stderr, "FAIL: iommufd_ioas_alloc err(%d)\n", err);
+		goto out_iommufd;
+	}
+
+	err = open_gpu_and_import_bar(&iommufd, argv[2], gpu_bar_index, gpu_bar_size, &gpu_dev,
+				      &gpu_bar_dmem, &gpu_bar_va, &gpu_bar_va_size);
+	if (err) {
+		goto out_ioas;
+	}
+	printf("gpu BAR imported: base_iova=0x%" PRIx64 " size=0x%" PRIx64
+	       ", cpu bar view=%p size=%zu\n",
+	       gpu_bar_dmem.base_iova, (uint64_t)gpu_bar_dmem.size, gpu_bar_va, gpu_bar_va_size);
+
+	/* Small hugepage-backed dmamem for the NVMe admin queue backing. */
+	err = dmamem_from_memfd(&admin_dmem, &iommufd, 2ULL * 1024 * 1024, 2ULL * 1024 * 1024);
+	if (err) {
+		fprintf(stderr, "FAIL: dmamem_from_memfd(admin) err(%d)\n", err);
+		goto out_gpu;
+	}
+	err = dmamem_heap_init(&admin_heap, &admin_dmem, 4096);
+	if (err) {
+		fprintf(stderr, "FAIL: dmamem_heap_init(admin) err(%d)\n", err);
+		goto out_admin_dmem;
+	}
+
+	err = nvme_controller_open_dmamem_vfio(&ctrlr, &nvme_ctx, &iommufd, &admin_heap, argv[1]);
+	if (err) {
+		fprintf(stderr, "FAIL: nvme_controller_open_dmamem_vfio err(%d)\n", err);
+		goto out_admin_heap;
+	}
+
+	/* Prime the GPU-side target region so we can distinguish DMA'd bytes from
+	 * whatever the last renderer left there. Writing to BAR VRAM through the
+	 * vfio mmap is uncached and slow but fine for a small region. */
+	memset((uint8_t *)gpu_bar_va + IDENTIFY_OFFSET, 0x00, 4096);
+
+	identify_iova = gpu_bar_dmem.base_iova + IDENTIFY_OFFSET;
+
+	cmd.opc = 0x06; /* IDENTIFY */
+	cmd.cid = 1;
+	cmd.prp1 = identify_iova;
+	cmd.cdw10 = 1; /* CNS=1: Identify Controller */
+
+	printf("issue: IDENTIFY CONTROLLER, PRP1=0x%" PRIx64 " (gpu VRAM IOVA base 0x%" PRIx64
+	       " + offset 0x%x)\n",
+	       identify_iova, gpu_bar_dmem.base_iova, IDENTIFY_OFFSET);
+
+	err = nvme_qpair_enqueue(&ctrlr.aq, &cmd);
+	if (err) {
+		fprintf(stderr, "FAIL: nvme_qpair_enqueue err(%d)\n", err);
+		goto out_ctrlr;
+	}
+	nvme_qpair_sqdb_update(&ctrlr.aq);
+
+	err = nvme_qpair_reap_cpl(&ctrlr.aq, ctrlr.timeout_ms, &cpl);
+	if (err) {
+		fprintf(stderr, "FAIL: nvme_qpair_reap_cpl err(%d)\n", err);
+		goto out_ctrlr;
+	}
+	if ((cpl.status >> 1) & 0x7FF) {
+		fprintf(stderr, "FAIL: IDENTIFY CQE status=0x%x\n", cpl.status);
+		err = -EIO;
+		goto out_ctrlr;
+	}
+
+	/* Peek at the VRAM at IDENTIFY_OFFSET via the BAR mmap and confirm the
+	 * identify data landed. The identify buffer layout:
+	 *   [4..23]  SN  (20 bytes)
+	 *   [24..63] MN  (40 bytes)
+	 *   [64..71] FR  (8 bytes)
+	 */
+	{
+		uint8_t *view = (uint8_t *)gpu_bar_va + IDENTIFY_OFFSET;
+		char sn[21] = {0}, mn[41] = {0}, fr[9] = {0};
+
+		memcpy(sn, view + 4, 20);
+		memcpy(mn, view + 24, 40);
+		memcpy(fr, view + 64, 8);
+		printf("VRAM peek: SN='%.20s' MN='%.40s' FR='%.8s'\n", sn, mn, fr);
+
+		if (sn[0] == 0 || (sn[0] == (char)0x00 && sn[1] == 0)) {
+			fprintf(stderr, "FAIL: VRAM at IDENTIFY_OFFSET still zeroed after DMA\n");
+			err = -EIO;
+			goto out_ctrlr;
+		}
+	}
+
+	printf("OK: NVMe DMAed IDENTIFY response into GPU VRAM through iommufd IOAS\n");
+
+	/*
+	 * WRITE from VRAM through an IO queue pair: the controller must *read*
+	 * GPU memory over PCIe (PRP1 in VRAM, data flowing device-inbound), the
+	 * more fragile peer direction. Create an IO qpair on the dmamem path,
+	 * prime a VRAM offset with a known pattern, WRITE it to LBA 0, then read
+	 * LBA 0 back into host memory and confirm the pattern round-tripped.
+	 * This overwrites LBA 0 on the DUT.
+	 */
+	{
+		struct nvme_qpair ioq = {0};
+		size_t ioq_sq = 0, ioq_cq = 0;
+		const uint32_t NSID = 1;
+		const uint32_t NBLOCKS_M1 = 7; /* 8 blocks (0-based) = 4 KiB */
+		const size_t WRITE_OFFSET = 0x4000;
+		uint8_t *vram = (uint8_t *)gpu_bar_va + WRITE_OFFSET;
+		uint64_t write_iova = gpu_bar_dmem.base_iova + WRITE_OFFSET;
+		size_t verify_off = 0;
+		uint8_t *verify_va;
+
+		err = nvme_controller_create_io_qpair_dmamem(&ctrlr, &ioq, 32, &admin_heap,
+							     &ioq_sq, &ioq_cq);
+		if (err) {
+			fprintf(stderr, "FAIL: nvme_controller_create_io_qpair_dmamem err(%d)\n",
+				err);
+			goto out_ctrlr;
+		}
+
+		err = dmamem_heap_alloc_aligned(&admin_heap, 4096, 4096, &verify_off);
+		if (err) {
+			fprintf(stderr, "FAIL: dmamem_heap_alloc_aligned(verify buf) err(%d)\n",
+				err);
+			goto io_done;
+		}
+		verify_va = dmamem_heap_at_va(&admin_heap, verify_off);
+
+		/* Prime the VRAM source with a recognizable pattern. */
+		for (size_t i = 0; i < 4096; i++) {
+			vram[i] = (uint8_t)(0xA5 ^ (i & 0xFF));
+		}
+
+		/* WRITE LBA 0 from VRAM: the controller reads GPU memory. */
+		memset(&cmd, 0, sizeof(cmd));
+		cmd.opc = 0x01; /* NVMe WRITE */
+		cmd.cid = 1;
+		cmd.nsid = NSID;
+		cmd.prp1 = write_iova;
+		cmd.cdw12 = NBLOCKS_M1;
+		printf("issue: NVMe WRITE LBA 0..%u <- PRP1=0x%" PRIx64
+		       " (VRAM IOVA base 0x%" PRIx64 " + offset 0x%zx)\n",
+		       NBLOCKS_M1 + 1, write_iova, gpu_bar_dmem.base_iova, WRITE_OFFSET);
+		err = nvme_submit_sync(&ioq, &cmd, ctrlr.timeout_ms);
+		if (err) {
+			fprintf(stderr, "FAIL: WRITE from VRAM err(%d)\n", err);
+			goto io_done;
+		}
+
+		/* Read LBA 0 back to host memory and confirm the pattern. */
+		memset(&cmd, 0, sizeof(cmd));
+		cmd.opc = 0x02; /* NVMe READ */
+		cmd.cid = 1;
+		cmd.nsid = NSID;
+		cmd.prp1 = dmamem_heap_at_iova(&admin_heap, verify_off);
+		cmd.cdw12 = NBLOCKS_M1;
+		err = nvme_submit_sync(&ioq, &cmd, ctrlr.timeout_ms);
+		if (err) {
+			fprintf(stderr, "FAIL: verify READ LBA 0 err(%d)\n", err);
+		} else if (memcmp(verify_va, vram, 4096) == 0) {
+			printf("OK: NVMe WRITE from VRAM round-tripped through LBA 0"
+			       " (device read GPU memory over PCIe)\n");
+		} else {
+			fprintf(stderr, "FAIL: LBA 0 readback does not match the VRAM pattern\n");
+			err = -EIO;
+		}
+
+io_done:
+		{
+			int derr = nvme_controller_delete_io_qpair_dmamem(
+				&ctrlr, &ioq, &admin_heap, ioq_sq, ioq_cq);
+			if (derr && !err) {
+				err = derr;
+			}
+		}
+	}
+
+out_ctrlr:
+	nvme_controller_close_dmamem_vfio(&ctrlr, &nvme_ctx, &admin_heap);
+out_admin_heap:
+	dmamem_heap_term(&admin_heap);
+out_admin_dmem:
+	dmamem_destroy(&admin_dmem);
+out_gpu:
+	if (gpu_bar_va) {
+		munmap(gpu_bar_va, gpu_bar_va_size);
+	}
+	dmamem_destroy(&gpu_bar_dmem);
+	iommufd_detach(&gpu_dev);
+	vfio_cdev_close(&gpu_dev);
+out_ioas:
+	iommufd_destroy(&iommufd, iommufd.ioas_id);
+out_iommufd:
+	iommufd_close(&iommufd);
+	return err ? 1 : 0;
+}

--- a/tests/test_dmamem_vfio_bar.c
+++ b/tests/test_dmamem_vfio_bar.c
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * dmamem_from_dmabuf via VFIO_DEVICE_FEATURE_DMA_BUF smoketest
+ * ============================================================
+ *
+ * The mainline-accepted dma-buf path: bind a vfio-pci device to iommufd,
+ * ask VFIO to export a slice of one of its BAR regions as a dma-buf, and
+ * pass that dma-buf fd to iommufd's IOMMU_IOAS_MAP_FILE via
+ * dmamem_from_dmabuf. As of Linux 6.19 the vfio-pci exporter is the only
+ * one iommufd's MAP_FILE accepts, so this is the current mainline test
+ * that a dma-buf + iommufd import actually works end to end.
+ *
+ * Usage:
+ *   test_dmamem_vfio_bar <cdev> <region_index> <length>
+ *   e.g.
+ *   test_dmamem_vfio_bar /dev/vfio/devices/vfio0 1 0x40000000
+ *
+ * On success prints the IOVA the kernel picked plus the dma-buf fd. On
+ * failure the errno at the ioctl surfaces exactly.
+ */
+#include <upcie/upcie.h>
+
+int
+main(int argc, char *argv[])
+{
+	struct iommufd iommufd = {0};
+	struct vfio_cdev dev = {0};
+	struct dmamem dmem = {0};
+	uint32_t region_index;
+	uint64_t length;
+	int dbuf_fd = -1;
+	int err;
+
+	if (argc != 4) {
+		fprintf(stderr, "usage: %s <cdev> <region_index> <length>\n", argv[0]);
+		return 2;
+	}
+	region_index = (uint32_t)strtoul(argv[2], NULL, 0);
+	length = (uint64_t)strtoull(argv[3], NULL, 0);
+
+	err = iommufd_open(&iommufd);
+	if (err) {
+		fprintf(stderr, "FAIL: iommufd_open() err(%d): %s\n", err, strerror(-err));
+		return 1;
+	}
+
+	err = iommufd_ioas_alloc(&iommufd);
+	if (err) {
+		fprintf(stderr, "FAIL: iommufd_ioas_alloc() err(%d): %s\n", err, strerror(-err));
+		goto out_iommufd;
+	}
+
+	err = vfio_cdev_open(argv[1], &dev);
+	if (err) {
+		fprintf(stderr, "FAIL: vfio_cdev_open('%s') err(%d): %s\n", argv[1], err,
+			strerror(-err));
+		goto out_ioas;
+	}
+
+	err = iommufd_bind(&iommufd, &dev);
+	if (err) {
+		fprintf(stderr, "FAIL: iommufd_bind() err(%d): %s\n", err, strerror(-err));
+		goto out_dev;
+	}
+
+	err = iommufd_attach(&iommufd, &dev);
+	if (err) {
+		fprintf(stderr, "FAIL: iommufd_attach() err(%d): %s\n", err,
+			strerror(-err));
+		goto out_dev;
+	}
+
+	dbuf_fd = vfio_device_bar_export_dmabuf(dev.fd, region_index, 0, length);
+	if (dbuf_fd < 0) {
+		fprintf(stderr, "FAIL: vfio_device_bar_export_dmabuf(region=%u, len=0x%" PRIx64
+				") err(%d): %s\n",
+			region_index, length, dbuf_fd, strerror(-dbuf_fd));
+		err = dbuf_fd;
+		goto out_detach;
+	}
+	printf("BAR dma-buf: fd=%d region=%u length=0x%" PRIx64 "\n", dbuf_fd, region_index,
+	       length);
+
+	err = dmamem_from_dmabuf(&dmem, &iommufd, dbuf_fd, length);
+	if (err) {
+		fprintf(stderr, "FAIL: dmamem_from_dmabuf() err(%d): %s\n", err, strerror(-err));
+		close(dbuf_fd);
+		goto out_detach;
+	}
+	dmamem_pp(&dmem);
+
+	printf("OK: base_iova=0x%" PRIx64 " size=%zu cpu_va=%s\n", dmem.base_iova, dmem.size,
+	       dmem.cpu_va ? "mapped" : "unavailable");
+
+	dmamem_destroy(&dmem);
+
+out_detach:
+	iommufd_detach(&dev);
+out_dev:
+	vfio_cdev_close(&dev);
+out_ioas:
+	iommufd_destroy(&iommufd, iommufd.ioas_id);
+out_iommufd:
+	iommufd_close(&iommufd);
+	return err ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Builds on #37. Adds the dma-buf constructor as a generic path that
imports any exporter's dma-buf fd into an iommufd IOAS via
IOMMU_IOAS_MAP_FILE, plus a vfio helper to export a device BAR
range as its own dma-buf. Together these are the current
mainline-viable route to peer DMA: vfio-pci is the one exporter
iommufd_ioas_map_file accepts on 6.19+, so any device sitting
behind a PCI BAR (NVMe doorbell page, NVMe CMB, GPU VRAM through
ReBAR) becomes reachable as a dmamem.

An end-to-end proof composes both: an NVMe controller and a
vfio-pci-bound GPU attach to the same iommufd IOAS, the GPU's BAR
is imported as a dmamem, and an NVMe IO qpair issues NVME_CMD_READ
from LBA 0 with PRP1 pointing into the GPU's VRAM IOVA. The 4 KiB
read lands directly in VRAM without CPU staging or downstream
kernel patches; CPU verification is via mmap of the same BAR
through the vfio device fd.

Follow-up: vfio-pci driver-level consolidation in #39, then
discriminated translator + LUT + uio_pci_generic and type1 siblings in #40.

## Reproduce on hardware

Extend the operator-local config from #37 with the GPU peer under
`[upcie.peer_gpu]` (bdf, bar_index, bar_size); a template lives in
configs/hw-example.toml. Then from cijoe/:

    cijoe tasks/deploy.yaml                     --config configs/<host>.toml
    cijoe tasks/dmamem_vfio_bar_smoketest.yaml  --config configs/<host>.toml
    cijoe tasks/dmamem_nvme_vram_smoketest.yaml --config configs/<host>.toml

The first stages binaries; the second confirms the BAR-as-dma-buf
leg on the target NVMe; the third binds both NVMe and GPU to
vfio-pci and runs the full end-to-end proof. Success prints
controller SN/MN/FR from IDENTIFY landing in VRAM plus the first
16 bytes of LBA 0 read through the IO qpair.