### PR TITLE
refactor(nvme): unify vfio-pci path + share bring-up helpers

### DIFF
--- a/cijoe/tasks/dmamem_driver_run.yaml
+++ b/cijoe/tasks/dmamem_driver_run.yaml
@@ -1,13 +1,15 @@
 ---
 doc: |
-  Run upcie_nvme_driver on the target NVMe with the dmamem backend.
+  Run upcie_nvme_driver on the target NVMe on the vfio-pci + iommufd
+  path.
 
   Assumes 'tasks/deploy.yaml' plus 'tasks/dmamem_nvme_identify.yaml'
-  have been run (NVMe already bound to vfio-pci). Sets
-  UPCIE_BACKEND=dmamem so upcie_nvme_driver takes the vfio-cdev +
-  iommufd + dmamem path. The target NVMe BDF is read from
-  config.upcie.dut.nvme_bdf.
+  have prepared the box (NVMe already bound to vfio-pci). Forces
+  UPCIE_VFIO_MODE=iommufd so the driver takes the vfio-cdev + iommufd
+  + dmamem path instead of the legacy vfio type1 container, even if
+  auto-select would otherwise agree. The target NVMe BDF is read
+  from config.upcie.dut.nvme_bdf.
 
 steps:
 - name: driver
-  run: 'ulimit -l unlimited; UPCIE_BACKEND=dmamem /tmp/upcie_source/builddir/example/upcie_nvme_driver {{ config.upcie.dut.nvme_bdf }}'
+  run: 'ulimit -l unlimited; UPCIE_VFIO_MODE=iommufd /tmp/upcie_source/builddir/example/upcie_nvme_driver {{ config.upcie.dut.nvme_bdf }}'

--- a/cijoe/tasks/dmamem_driver_run_type1.yaml
+++ b/cijoe/tasks/dmamem_driver_run_type1.yaml
@@ -1,0 +1,15 @@
+---
+doc: |
+  Run upcie_nvme_driver on the target NVMe forced to the legacy vfio
+  type1 container path.
+
+  Same prerequisites as tasks/dmamem_driver_run.yaml (NVMe already
+  bound to vfio-pci). Sets UPCIE_VFIO_MODE=type1 so the driver
+  bypasses auto-select and opens the controller through the vfio
+  type1 container + hostmem, even on a target where iommufd would be
+  available. Useful for a regression triage between the two DMA
+  APIs. The target NVMe BDF is read from config.upcie.dut.nvme_bdf.
+
+steps:
+- name: driver
+  run: 'ulimit -l unlimited; UPCIE_VFIO_MODE=type1 /tmp/upcie_source/builddir/example/upcie_nvme_driver {{ config.upcie.dut.nvme_bdf }}'

--- a/example/upcie_nvme_driver.c
+++ b/example/upcie_nvme_driver.c
@@ -7,10 +7,41 @@
 #include <upcie/upcie.h>
 
 enum nvme_backend {
-	NVME_BACKEND_SYSFS = 0,
-	NVME_BACKEND_VFIO,
-	NVME_BACKEND_DMAMEM,
+	NVME_BACKEND_SYSFS = 0,    ///< uio_pci_generic + hostmem
+	NVME_BACKEND_VFIO_TYPE1,   ///< vfio-pci + vfio type1 container + hostmem
+	NVME_BACKEND_VFIO_IOMMUFD, ///< vfio-pci + iommufd + dmamem
 };
+
+static int
+iommufd_available(void)
+{
+#ifdef IOMMU_IOAS_MAP_FILE
+	return access("/dev/iommu", R_OK | W_OK) == 0;
+#else
+	return 0;
+#endif
+}
+
+/*
+ * Pick the vfio-pci DMA backend from UPCIE_VFIO_MODE (auto|type1|iommufd);
+ * auto uses iommufd when /dev/iommu is usable, otherwise legacy vfio type1.
+ */
+static enum nvme_backend
+resolve_vfio_backend(void)
+{
+	const char *mode = getenv("UPCIE_VFIO_MODE");
+
+	if (mode && !strcmp(mode, "type1")) {
+		return NVME_BACKEND_VFIO_TYPE1;
+	}
+	if (mode && !strcmp(mode, "iommufd")) {
+		return NVME_BACKEND_VFIO_IOMMUFD;
+	}
+	if (mode && *mode && strcmp(mode, "auto")) {
+		printf("WARN: UPCIE_VFIO_MODE='%s' unknown; using auto\n", mode);
+	}
+	return iommufd_available() ? NVME_BACKEND_VFIO_IOMMUFD : NVME_BACKEND_VFIO_TYPE1;
+}
 
 struct rte {
 	struct hostmem_config config;
@@ -97,12 +128,12 @@ nvme_cleanup(struct nvme *nvme)
 		memset(&nvme->ioq, 0, sizeof(nvme->ioq));
 	}
 
-	if (nvme->backend == NVME_BACKEND_VFIO) {
+	if (nvme->backend == NVME_BACKEND_VFIO_TYPE1) {
 		nvme_controller_close_vfio(&nvme->ctrlr, &nvme->vfio);
 		return;
 	}
 
-	if (nvme->backend == NVME_BACKEND_DMAMEM) {
+	if (nvme->backend == NVME_BACKEND_VFIO_IOMMUFD) {
 		if (nvme->dm.buf) {
 			dmamem_heap_free(&nvme->dm.heap, nvme->dm.buf_off);
 			nvme->dm.buf = NULL;
@@ -257,23 +288,7 @@ nvme_init(struct nvme *nvme, const char *bdf, struct rte *rte)
 	char driver_name[NAME_MAX + 1] = {0};
 	struct nvme_completion cpl = {0};
 	struct nvme_command cmd = {0};
-	const char *backend_env = getenv("UPCIE_BACKEND");
 	int err;
-
-	if (backend_env && !strcmp(backend_env, "dmamem")) {
-		nvme->backend = NVME_BACKEND_DMAMEM;
-		err = nvme_open_dmamem(nvme, bdf);
-		if (err) {
-			return err;
-		}
-		err = nvme_identify_dmamem(nvme);
-		if (err) {
-			printf("FAILED: nvme_identify_dmamem(); err(%d)\n", err);
-			nvme_cleanup(nvme);
-			return err;
-		}
-		return 0;
-	}
 
 	err = device_get_driver_name(bdf, driver_name, sizeof(driver_name));
 	if (err) {
@@ -281,12 +296,25 @@ nvme_init(struct nvme *nvme, const char *bdf, struct rte *rte)
 		return err;
 	}
 
-	if (!strcmp(driver_name, "vfio-pci")) {
-		nvme->backend = NVME_BACKEND_VFIO;
-		err = nvme_controller_open_vfio(&nvme->ctrlr, &nvme->vfio, bdf, &rte->heap);
-	} else if (!strcmp(driver_name, "uio_pci_generic")) {
+	if (!strcmp(driver_name, "uio_pci_generic")) {
 		nvme->backend = NVME_BACKEND_SYSFS;
 		err = nvme_controller_open(&nvme->ctrlr, bdf, &rte->heap);
+	} else if (!strcmp(driver_name, "vfio-pci")) {
+		nvme->backend = resolve_vfio_backend();
+		if (nvme->backend == NVME_BACKEND_VFIO_IOMMUFD) {
+			err = nvme_open_dmamem(nvme, bdf);
+			if (err) {
+				return err;
+			}
+			err = nvme_identify_dmamem(nvme);
+			if (err) {
+				printf("FAILED: nvme_identify_dmamem(); err(%d)\n", err);
+				nvme_cleanup(nvme);
+				return err;
+			}
+			return 0;
+		}
+		err = nvme_controller_open_vfio(&nvme->ctrlr, &nvme->vfio, bdf, &rte->heap);
 	} else {
 		printf("FAILED: unsupported driver '%s'\n", driver_name);
 		return -ENOTSUP;
@@ -315,7 +343,7 @@ nvme_init(struct nvme *nvme, const char *bdf, struct rte *rte)
 	if (err) {
 		printf("FAILED: nvme_device_create_io_qpair(); err(%d)\n", err);
 
-		if (nvme->backend == NVME_BACKEND_VFIO) {
+		if (nvme->backend == NVME_BACKEND_VFIO_TYPE1) {
 			nvme_controller_close_vfio(&nvme->ctrlr, &nvme->vfio);
 		} else {
 			nvme_controller_close(&nvme->ctrlr);

--- a/include/upcie/nvme/nvme_controller_dmamem_vfio.h
+++ b/include/upcie/nvme/nvme_controller_dmamem_vfio.h
@@ -83,42 +83,6 @@ nvme_dmamem_vfio_ctx_close(struct nvme_dmamem_vfio_ctx *ctx)
 }
 
 /**
- * Enable PCI bus master on the vfio device via config-space write.
- *
- * The dmamem controller relies on the device DMAing into IOAS-mapped
- * memory, which requires BM=1.
- */
-static inline int
-nvme_dmamem_pci_bus_master_enable(int device_fd)
-{
-	struct vfio_region_info config = {0};
-	uint16_t cmd;
-	ssize_t ret;
-	int err;
-
-	config.index = VFIO_PCI_CONFIG_REGION_INDEX;
-	err = vfio_device_get_region_info(device_fd, &config);
-	if (err < 0) {
-		return -errno;
-	}
-
-	ret = pread(device_fd, &cmd, sizeof(cmd), config.offset + PCI_COMMAND);
-	if (ret != (ssize_t)sizeof(cmd)) {
-		return ret < 0 ? -errno : -EIO;
-	}
-
-	if (!(cmd & PCI_COMMAND_MASTER)) {
-		cmd |= PCI_COMMAND_MASTER;
-		ret = pwrite(device_fd, &cmd, sizeof(cmd), config.offset + PCI_COMMAND);
-		if (ret != (ssize_t)sizeof(cmd)) {
-			return ret < 0 ? -errno : -EIO;
-		}
-	}
-
-	return 0;
-}
-
-/**
  * Allocate SQ and CQ for a queue pair from a dmamem_heap and populate the
  * nvme_qpair fields the submit/reap primitives read.
  *
@@ -225,7 +189,6 @@ nvme_controller_open_dmamem_vfio(struct nvme_controller *ctrlr, struct nvme_dmam
 			    struct iommufd *iommufd, struct dmamem_heap *heap,
 			    const char *vfio_device_path)
 {
-	struct vfio_region_info region = {0};
 	uint64_t sq_iova = 0, cq_iova = 0;
 	uint64_t cap;
 	void *bar0;
@@ -260,41 +223,14 @@ nvme_controller_open_dmamem_vfio(struct nvme_controller *ctrlr, struct nvme_dmam
 	}
 	ctx->attached = 1;
 
-	err = nvme_dmamem_pci_bus_master_enable(ctx->dev.fd);
+	err = nvme_vfio_pci_acquire_bar0(ctx->dev.fd, ctrlr, &ctx->bar0, &ctx->bar0_size);
 	if (err) {
-		UPCIE_DEBUG("FAILED: nvme_dmamem_pci_bus_master_enable(); err(%d)", err);
 		goto fail;
 	}
+	bar0 = ctx->bar0;
 
-	region.index = VFIO_PCI_BAR0_REGION_INDEX;
-	err = vfio_device_get_region_info(ctx->dev.fd, &region);
-	if (err < 0) {
-		err = -errno;
-		UPCIE_DEBUG("FAILED: vfio_device_get_region_info(); errno(%d)", errno);
-		goto fail;
-	}
-
-	bar0 = vfio_map_region(ctx->dev.fd, region.size, region.offset);
-	if (bar0 == MAP_FAILED) {
-		err = -errno;
-		UPCIE_DEBUG("FAILED: vfio_map_region(); errno(%d)", errno);
-		goto fail;
-	}
-	ctx->bar0 = bar0;
-	ctx->bar0_size = region.size;
-
-	ctrlr->func.bars[0].region = bar0;
-	ctrlr->func.bars[0].size = region.size;
-	ctrlr->func.bars[0].id = 0;
-	ctrlr->func.bars[0].fd = ctx->dev.fd;
-
-	cap = nvme_mmio_cap_read(bar0);
-	ctrlr->timeout_ms = nvme_reg_cap_get_to(cap) * 500;
-
-	nvme_mmio_cc_disable(bar0);
-	err = nvme_mmio_csts_wait_until_not_ready(bar0, ctrlr->timeout_ms);
+	err = nvme_controller_reset_via_bar0(ctrlr, bar0, &cap);
 	if (err) {
-		UPCIE_DEBUG("FAILED: nvme_mmio_csts_wait_until_not_ready(); err(%d)", err);
 		goto fail;
 	}
 
@@ -308,24 +244,8 @@ nvme_controller_open_dmamem_vfio(struct nvme_controller *ctrlr, struct nvme_dmam
 
 	nvme_mmio_aq_setup(bar0, sq_iova, cq_iova, ctrlr->aq.depth);
 
-	{
-		uint32_t css = (nvme_reg_cap_get_css(cap) & (1 << 6)) ? 0x6 : 0x0;
-		uint32_t cc = 0;
-
-		cc = nvme_reg_cc_set_css(cc, css);
-		cc = nvme_reg_cc_set_shn(cc, 0x0);
-		cc = nvme_reg_cc_set_mps(cc, 0x0);
-		cc = nvme_reg_cc_set_ams(cc, 0x0);
-		cc = nvme_reg_cc_set_iosqes(cc, 6);
-		cc = nvme_reg_cc_set_iocqes(cc, 4);
-		cc = nvme_reg_cc_set_en(cc, 0x1);
-
-		nvme_mmio_cc_write(bar0, cc);
-	}
-
-	err = nvme_mmio_csts_wait_until_ready(bar0, ctrlr->timeout_ms);
+	err = nvme_controller_enable_via_bar0(ctrlr, bar0, cap);
 	if (err) {
-		UPCIE_DEBUG("FAILED: nvme_mmio_csts_wait_until_ready(); err(%d)", err);
 		goto fail;
 	}
 

--- a/include/upcie/nvme/nvme_controller_vfio.h
+++ b/include/upcie/nvme/nvme_controller_vfio.h
@@ -6,7 +6,7 @@
 /**
  * VFIO NVMe Controller Extension
  * ==============================
- * 
+ *
  * @file nvme_controller_vfio.h
  * @version 0.5.1
  */
@@ -22,36 +22,6 @@ struct vfio_ctx {
 	size_t bar0_size;
 	int iommu_set;
 };
-
-static inline int
-nvme_vfio_pci_bus_master_enable(int device_fd)
-{
-	struct vfio_region_info config = {0};
-	uint16_t cmd;
-	ssize_t ret;
-	int err;
-
-	config.index = VFIO_PCI_CONFIG_REGION_INDEX;
-	err = vfio_device_get_region_info(device_fd, &config);
-	if (err < 0) {
-		return -errno;
-	}
-
-	ret = pread(device_fd, &cmd, sizeof(cmd), config.offset + PCI_COMMAND);
-	if (ret != (ssize_t)sizeof(cmd)) {
-		return ret < 0 ? -errno : -EIO;
-	}
-
-	if (!(cmd & PCI_COMMAND_MASTER)) {
-		cmd |= PCI_COMMAND_MASTER;
-		ret = pwrite(device_fd, &cmd, sizeof(cmd), config.offset + PCI_COMMAND);
-		if (ret != (ssize_t)sizeof(cmd)) {
-			return ret < 0 ? -errno : -EIO;
-		}
-	}
-
-	return 0;
-}
 
 static inline void
 nvme_vfio_ctx_init(struct vfio_ctx *vfio)
@@ -218,7 +188,6 @@ static inline int
 nvme_controller_open_vfio(struct nvme_controller *ctrlr, struct vfio_ctx *vfio, const char *bdf,
 			  struct hostmem_heap *heap)
 {
-	struct vfio_region_info region = {0};
 	int api_version = 0;
 	int group_id = -1;
 	uint64_t cap;
@@ -316,44 +285,14 @@ nvme_controller_open_vfio(struct nvme_controller *ctrlr, struct vfio_ctx *vfio, 
 		goto fail;
 	}
 
-	err = nvme_vfio_pci_bus_master_enable(vfio->device_fd);
+	err = nvme_vfio_pci_acquire_bar0(vfio->device_fd, ctrlr, &vfio->bar0, &vfio->bar0_size);
 	if (err) {
-		UPCIE_DEBUG("FAILED: nvme_vfio_pci_bus_master_enable(); err(%d)", err);
 		goto fail;
 	}
+	bar0 = vfio->bar0;
 
-	region.index = VFIO_PCI_BAR0_REGION_INDEX;
-	err = vfio_device_get_region_info(vfio->device_fd, &region);
-	if (err < 0) {
-		err = -errno;
-		UPCIE_DEBUG("FAILED: vfio_device_get_region_info(); errno(%d)", errno);
-		goto fail;
-	}
-
-	bar0 = vfio_map_region(vfio->device_fd, region.size, region.offset);
-	if (bar0 == MAP_FAILED) {
-		err = -errno;
-		UPCIE_DEBUG("FAILED: vfio_map_region(); errno(%d)", errno);
-		goto fail;
-	}
-
-	vfio->bar0 = bar0;
-	vfio->bar0_size = region.size;
-	ctrlr->func.bars[0].region = bar0;
-	ctrlr->func.bars[0].size = region.size;
-	ctrlr->func.bars[0].id = 0;
-	ctrlr->func.bars[0].fd = vfio->device_fd;
-
-	// Continue with the common NVMe controller initialization
-	cap = nvme_mmio_cap_read(bar0);
-	// CAP.TO is encoded in units of 500 ms.
-	ctrlr->timeout_ms = nvme_reg_cap_get_to(cap) * 500;
-
-	nvme_mmio_cc_disable(bar0);
-
-	err = nvme_mmio_csts_wait_until_not_ready(bar0, ctrlr->timeout_ms);
+	err = nvme_controller_reset_via_bar0(ctrlr, bar0, &cap);
 	if (err) {
-		UPCIE_DEBUG("FAILED: nvme_mmio_csts_wait_until_not_ready(); err(%d)", err);
 		goto fail;
 	}
 
@@ -366,24 +305,8 @@ nvme_controller_open_vfio(struct nvme_controller *ctrlr, struct vfio_ctx *vfio, 
 	nvme_mmio_aq_setup(bar0, hostmem_dma_v2p(heap, ctrlr->aq.sq),
 			   hostmem_dma_v2p(heap, ctrlr->aq.cq), ctrlr->aq.depth);
 
-	{
-		uint32_t css = (nvme_reg_cap_get_css(cap) & (1 << 6)) ? 0x6 : 0x0;
-		uint32_t cc = 0;
-
-		cc = nvme_reg_cc_set_css(cc, css);
-		cc = nvme_reg_cc_set_shn(cc, 0x0);
-		cc = nvme_reg_cc_set_mps(cc, 0x0);
-		cc = nvme_reg_cc_set_ams(cc, 0x0);
-		cc = nvme_reg_cc_set_iosqes(cc, 6);
-		cc = nvme_reg_cc_set_iocqes(cc, 4);
-		cc = nvme_reg_cc_set_en(cc, 0x1);
-
-		nvme_mmio_cc_write(bar0, cc);
-	}
-
-	err = nvme_mmio_csts_wait_until_ready(bar0, ctrlr->timeout_ms);
+	err = nvme_controller_enable_via_bar0(ctrlr, bar0, cap);
 	if (err) {
-		UPCIE_DEBUG("FAILED: nvme_mmio_csts_wait_until_ready(); err(%d)", err);
 		goto fail;
 	}
 

--- a/include/upcie/nvme/nvme_controller_vfio_pci.h
+++ b/include/upcie/nvme/nvme_controller_vfio_pci.h
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * NVMe controller bring-up helpers shared across vfio-pci backings
+ * ================================================================
+ *
+ * From a caller-supplied vfio device fd, acquire BAR0 and drive the
+ * NVMe controller enable sequence. Both nvme_controller_open_vfio
+ * (legacy vfio type1 container) and nvme_controller_open_dmamem_vfio
+ * (iommufd + dmamem) reach the same code once they have a device fd:
+ * bus-master enable, BAR0 mmap, CC.EN=0/1 dance, CAP/CSTS handshake.
+ * That invariant middle lives here. The parts that vary (how the fd
+ * was obtained, how DMA is mapped, which heap backs the admin queue)
+ * stay with each caller.
+ *
+ * @file nvme_controller_vfio_pci.h
+ * @version 0.5.1
+ */
+
+/**
+ * Enable PCI bus master on a vfio device via config-space write.
+ *
+ * The controller needs BM=1 to DMA into any host- or peer-mapped
+ * memory, regardless of which DMA API installed the mapping.
+ */
+static inline int
+nvme_vfio_pci_bus_master_enable(int device_fd)
+{
+	struct vfio_region_info config = {0};
+	uint16_t cmd;
+	ssize_t ret;
+	int err;
+
+	config.index = VFIO_PCI_CONFIG_REGION_INDEX;
+	err = vfio_device_get_region_info(device_fd, &config);
+	if (err < 0) {
+		return -errno;
+	}
+
+	ret = pread(device_fd, &cmd, sizeof(cmd), config.offset + PCI_COMMAND);
+	if (ret != (ssize_t)sizeof(cmd)) {
+		return ret < 0 ? -errno : -EIO;
+	}
+
+	if (!(cmd & PCI_COMMAND_MASTER)) {
+		cmd |= PCI_COMMAND_MASTER;
+		ret = pwrite(device_fd, &cmd, sizeof(cmd), config.offset + PCI_COMMAND);
+		if (ret != (ssize_t)sizeof(cmd)) {
+			return ret < 0 ? -errno : -EIO;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * Acquire BAR0 for the given vfio device.
+ *
+ * Enables bus master, mmap's BAR0 through the vfio fd, and populates
+ * ctrlr->func.bars[0] so the submit/reap primitives can find the
+ * doorbell region.
+ *
+ * @param device_fd      Open vfio device fd (obtained from a group or
+ *                       from an iommufd cdev bind).
+ * @param ctrlr          Controller descriptor; func.bars[0] is filled in.
+ * @param bar0_out       On success, the mmap'd BAR0 base.
+ * @param bar0_size_out  On success, the mapping length.
+ *
+ * @return 0 on success, negative errno on error.
+ */
+static inline int
+nvme_vfio_pci_acquire_bar0(int device_fd, struct nvme_controller *ctrlr, void **bar0_out,
+			   size_t *bar0_size_out)
+{
+	struct vfio_region_info region = {0};
+	void *bar0;
+	int err;
+
+	err = nvme_vfio_pci_bus_master_enable(device_fd);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_vfio_pci_bus_master_enable(); err(%d)", err);
+		return err;
+	}
+
+	region.index = VFIO_PCI_BAR0_REGION_INDEX;
+	err = vfio_device_get_region_info(device_fd, &region);
+	if (err < 0) {
+		UPCIE_DEBUG("FAILED: vfio_device_get_region_info(); errno(%d)", errno);
+		return -errno;
+	}
+
+	bar0 = vfio_map_region(device_fd, region.size, region.offset);
+	if (bar0 == MAP_FAILED) {
+		UPCIE_DEBUG("FAILED: vfio_map_region(); errno(%d)", errno);
+		return -errno;
+	}
+
+	ctrlr->func.bars[0].region = bar0;
+	ctrlr->func.bars[0].size = region.size;
+	ctrlr->func.bars[0].id = 0;
+	ctrlr->func.bars[0].fd = device_fd;
+
+	*bar0_out = bar0;
+	*bar0_size_out = region.size;
+
+	return 0;
+}
+
+/**
+ * Read CAP, derive controller timeout, disable the controller, wait
+ * for CSTS.RDY=0.
+ *
+ * The caller uses *cap_out when programming CC on enable.
+ */
+static inline int
+nvme_controller_reset_via_bar0(struct nvme_controller *ctrlr, uint8_t *bar0, uint64_t *cap_out)
+{
+	uint64_t cap = nvme_mmio_cap_read(bar0);
+	int err;
+
+	ctrlr->timeout_ms = nvme_reg_cap_get_to(cap) * 500;
+
+	nvme_mmio_cc_disable(bar0);
+
+	err = nvme_mmio_csts_wait_until_not_ready(bar0, ctrlr->timeout_ms);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_mmio_csts_wait_until_not_ready(); err(%d)", err);
+		return err;
+	}
+
+	*cap_out = cap;
+	return 0;
+}
+
+/**
+ * Program CC with the standard defaults and wait for CSTS.RDY=1.
+ *
+ * The AQA/ASQ/ACQ programming must have already happened (via
+ * nvme_mmio_aq_setup) so the controller finds the admin queue on
+ * enable.
+ */
+static inline int
+nvme_controller_enable_via_bar0(struct nvme_controller *ctrlr, uint8_t *bar0, uint64_t cap)
+{
+	uint32_t css = (nvme_reg_cap_get_css(cap) & (1 << 6)) ? 0x6 : 0x0;
+	uint32_t cc = 0;
+	int err;
+
+	cc = nvme_reg_cc_set_css(cc, css);
+	cc = nvme_reg_cc_set_shn(cc, 0x0);
+	cc = nvme_reg_cc_set_mps(cc, 0x0);
+	cc = nvme_reg_cc_set_ams(cc, 0x0);
+	cc = nvme_reg_cc_set_iosqes(cc, 6);
+	cc = nvme_reg_cc_set_iocqes(cc, 4);
+	cc = nvme_reg_cc_set_en(cc, 0x1);
+
+	nvme_mmio_cc_write(bar0, cc);
+
+	err = nvme_mmio_csts_wait_until_ready(bar0, ctrlr->timeout_ms);
+	if (err) {
+		UPCIE_DEBUG("FAILED: nvme_mmio_csts_wait_until_ready(); err(%d)", err);
+		return err;
+	}
+
+	return 0;
+}

--- a/include/upcie/upcie.h
+++ b/include/upcie/upcie.h
@@ -94,6 +94,7 @@ extern "C" {
 #include <upcie/nvme/nvme_qid.h>
 #include <upcie/nvme/nvme_qpair.h>
 #include <upcie/nvme/nvme_controller.h>
+#include <upcie/nvme/nvme_controller_vfio_pci.h>
 #include <upcie/nvme/nvme_controller_vfio.h>
 #include <upcie/nvme/nvme_controller_dmamem_vfio.h>
 #endif

--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,7 @@ install_headers(
     'include/upcie/nvme/nvme_controller.h',
     'include/upcie/nvme/nvme_controller_dmamem_vfio.h',
     'include/upcie/nvme/nvme_controller_vfio.h',
+    'include/upcie/nvme/nvme_controller_vfio_pci.h',
     'include/upcie/nvme/nvme_controller_cuda.h',
     'include/upcie/nvme/nvme_mmio.h',
     'include/upcie/nvme/nvme_qid.h',


### PR DESCRIPTION
## Summary

Builds on the dma-buf PR. Consolidates the two vfio-pci-consuming
backends now that both exist.

The driver-level unification collapses the previously disjoint
BACKEND_VFIO and BACKEND_DMAMEM switch cases in upcie_nvme_driver
into one vfio-pci path with two branches on the DMA API. Selection
runs at runtime via UPCIE_VFIO_MODE (auto|type1|iommufd) with a
capability-based default that picks iommufd whenever /dev/iommu is
usable and IOMMU_IOAS_MAP_FILE is compiled in, and falls back to
the legacy vfio type1 container otherwise. The prior
UPCIE_BACKEND=dmamem opt-in goes away with this change.

The header-level extraction moves the invariant portion of the
bring-up sequence (bus master enable, BAR0 mmap and ctrlr func.bars
population, CAP read, CC.EN=0 and CSTS.RDY=0 wait, CC.EN=1 and
CSTS.RDY=1 wait) into nvme_controller_vfio_pci.h. The two open
functions differ only in how they get a vfio device fd (type1 group
vs iommufd cdev bind), how DMA is mapped (VFIO_IOMMU_MAP_DMA vs
IOMMU_IOAS_MAP_FILE), and which heap backs the admin queue (hostmem
vs dmamem); everything else was line-for-line duplicated across the
two backend headers.

Follow-up: discriminated translator + LUT + uio_pci_generic and type1 siblings
in #40, which stacks nvme_controller_dmamem_uio + nvme_controller_dmamem_type1 next to
nvme_controller_dmamem_vfio and shares this PR's
nvme_controller_vfio_pci helpers where they apply.

## Reproduce on hardware

Reuse the config from #37 (target NVMe under config.upcie.dut).
Then exercise both DMA-API branches from cijoe/:

    cijoe tasks/deploy.yaml                    --config configs/<host>.toml
    cijoe tasks/dmamem_driver_run.yaml         --config configs/<host>.toml
    cijoe tasks/dmamem_driver_run_type1.yaml   --config configs/<host>.toml

The first stages binaries; the second forces UPCIE_VFIO_MODE=iommufd
so the driver takes the vfio-cdev + iommufd + dmamem path; the third
forces UPCIE_VFIO_MODE=type1 so the same driver goes through the
legacy vfio type1 container + hostmem path. Both should IDENTIFY
the controller and print SN/MN.