### PR TITLE
feat(nvme): one PRP builder for host and device buffers

### DIFF
--- a/include/upcie/dmamem.h
+++ b/include/upcie/dmamem.h
@@ -92,6 +92,7 @@ struct vfio_container;
  */
 struct dmamem {
 	int fd;                     ///< memfd or dma-buf when owned=1; -1 when wrapping
+	void *base_va;              ///< Base of the address space offsets are measured from
 	void *cpu_va;               ///< CPU virtual address, NULL when not mappable
 	size_t size;                ///< Size in bytes
 	uint64_t base_iova;         ///< Base IOVA (ARITHMETIC translator only)
@@ -122,6 +123,7 @@ dmamem_pp(struct dmamem *dmem)
 
 	wrtn += printf("\n");
 	wrtn += printf("  fd: %d\n", dmem->fd);
+	wrtn += printf("  base_va: %p\n", dmem->base_va);
 	wrtn += printf("  cpu_va: %p\n", dmem->cpu_va);
 	wrtn += printf("  size: %zu\n", dmem->size);
 	wrtn += printf("  base_iova: 0x%" PRIx64 "\n", dmem->base_iova);
@@ -183,13 +185,16 @@ dmamem_offset_to_iova(struct dmamem *dmem, size_t offset)
  * Convert a CPU VA inside the dmamem to an IOVA.
  *
  * Only usable when the backing exposes a CPU VA. Callers must assert
- * dmem->cpu_va != NULL before invoking; the fast path does not check.
+ * dmem->base_va != NULL before invoking; the fast path does not check.
+ *
+ * 'vaddr' lies in whatever space the dmamem describes: a CPU mapping for
+ * host memory, a device pointer for GPU memory.
  */
 static inline uint64_t
 dmamem_va_to_iova(struct dmamem *dmem, void *vaddr)
 {
-	assert(dmem->cpu_va);
-	return dmamem_offset_to_iova(dmem, (size_t)((char *)vaddr - (char *)dmem->cpu_va));
+	assert(dmem->base_va);
+	return dmamem_offset_to_iova(dmem, (size_t)((char *)vaddr - (char *)dmem->base_va));
 }
 
 /**

--- a/include/upcie/dmamem.h
+++ b/include/upcie/dmamem.h
@@ -67,15 +67,22 @@ enum dmamem_backing {
 };
 
 /**
- * How offsets resolve to DMA addresses at submission.
+ * How offsets resolve to the address the device puts on the bus.
+ *
+ * "iova" is used throughout for that address, as DPDK does, but what it
+ * holds depends on the translator: a kernel-assigned IOVA when a mapping
+ * was installed, a physical or bus address when none was.
  *
  * ARITHMETIC = 0 by intent: a memset-to-zero dmamem is arithmetic by
  * default, which is what every current owned constructor produces
  * without extra code.
  */
 enum dmamem_translator {
-	DMAMEM_XLATE_ARITHMETIC = 0x0, ///< iova = base_iova + offset
-	DMAMEM_XLATE_LUT = 0x1,        ///< iova = phys_lut[off >> shift] + (off & mask)
+	/** iova = base_iova + offset; the IOVA of the installed mapping. */
+	DMAMEM_XLATE_ARITHMETIC = 0x0,
+	/** iova = phys_lut[off >> shift] + (off & mask); an address the device
+	 *  uses directly, no translation installed. */
+	DMAMEM_XLATE_LUT = 0x1,
 };
 
 /* Forward-declare so dmamem.h stays independent of vfioctl.h include
@@ -169,6 +176,9 @@ dmamem_lut_pagesize_shift(size_t pagesize)
  * The submission-path function. One compare on dmem->translator,
  * then either a single addition (ARITHMETIC) or a shift + table
  * lookup + addition (LUT).
+ *
+ * The result is a kernel-assigned IOVA under the ARITHMETIC translator and
+ * a physical or bus address under LUT; see enum dmamem_translator.
  */
 static inline uint64_t
 dmamem_offset_to_iova(struct dmamem *dmem, size_t offset)

--- a/include/upcie/dmamem_cuda.h
+++ b/include/upcie/dmamem_cuda.h
@@ -54,7 +54,8 @@ dmamem_from_cuda_lut(struct dmamem *dmem, struct cudamem_heap *heap)
 
 	memset(dmem, 0, sizeof(*dmem));
 	dmem->fd = -1;
-	dmem->cpu_va = NULL; /* Device VA; not CPU-mappable. Callers use offsets. */
+	dmem->base_va = (void *)(uintptr_t)heap->vaddr;
+	dmem->cpu_va = NULL;
 	dmem->size = heap->size;
 	dmem->backing = DMAMEM_BACKING_CUDAMEM;
 	dmem->translator = DMAMEM_XLATE_LUT;

--- a/include/upcie/dmamem_dmabuf.h
+++ b/include/upcie/dmamem_dmabuf.h
@@ -62,6 +62,7 @@ dmamem_from_dmabuf(struct dmamem *dmem, struct iommufd *iommufd, int dmabuf_fd, 
 	cpu_va = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, dmabuf_fd, 0);
 	if (cpu_va != MAP_FAILED) {
 		dmem->cpu_va = cpu_va;
+		dmem->base_va = cpu_va;
 	}
 
 	err = iommufd_ioas_map_file(iommufd, dmabuf_fd, 0, size,

--- a/include/upcie/dmamem_heap.h
+++ b/include/upcie/dmamem_heap.h
@@ -247,15 +247,18 @@ dmamem_heap_free(struct dmamem_heap *heap, size_t offset)
 }
 
 /**
- * Return the CPU VA of an allocation, or NULL for non-CPU-mappable backings.
+ * Return the address of an allocation in the space the dmamem describes.
+ *
+ * A CPU pointer for host-backed dmamems, a device pointer for GPU-backed
+ * ones; dereference only when dmem->cpu_va is set.
  */
 static inline void *
 dmamem_heap_at_va(struct dmamem_heap *heap, size_t offset)
 {
-	if (!heap || !heap->dmem || !heap->dmem->cpu_va) {
+	if (!heap || !heap->dmem || !heap->dmem->base_va) {
 		return NULL;
 	}
-	return (char *)heap->dmem->cpu_va + offset;
+	return (char *)heap->dmem->base_va + offset;
 }
 
 /**

--- a/include/upcie/dmamem_hip.h
+++ b/include/upcie/dmamem_hip.h
@@ -54,7 +54,8 @@ dmamem_from_hip_lut(struct dmamem *dmem, struct hipmem_heap *heap)
 
 	memset(dmem, 0, sizeof(*dmem));
 	dmem->fd = -1;
-	dmem->cpu_va = NULL; /* Device VA; not CPU-mappable. Callers use offsets. */
+	dmem->base_va = (void *)(uintptr_t)heap->vaddr;
+	dmem->cpu_va = NULL;
 	dmem->size = heap->size;
 	dmem->backing = DMAMEM_BACKING_HIPMEM;
 	dmem->translator = DMAMEM_XLATE_LUT;

--- a/include/upcie/dmamem_hostmem.h
+++ b/include/upcie/dmamem_hostmem.h
@@ -55,6 +55,7 @@ dmamem_from_hostmem_iommufd(struct dmamem *dmem, struct iommufd *iommufd,
 	memset(dmem, 0, sizeof(*dmem));
 	dmem->fd = -1;
 	dmem->cpu_va = hp->virt;
+	dmem->base_va = dmem->cpu_va;
 	dmem->size = hp->size;
 	dmem->iommufd = iommufd;
 	dmem->backing = DMAMEM_BACKING_HOSTMEM;
@@ -95,6 +96,7 @@ dmamem_from_hostmem_type1(struct dmamem *dmem, struct vfio_container *container,
 	memset(dmem, 0, sizeof(*dmem));
 	dmem->fd = -1;
 	dmem->cpu_va = hp->virt;
+	dmem->base_va = dmem->cpu_va;
 	dmem->size = hp->size;
 	dmem->base_iova = base_iova;
 	dmem->vfio_container = container;
@@ -147,6 +149,7 @@ dmamem_from_hostmem_lut(struct dmamem *dmem, struct hostmem_hugepage *hp)
 	memset(dmem, 0, sizeof(*dmem));
 	dmem->fd = -1;
 	dmem->cpu_va = hp->virt;
+	dmem->base_va = dmem->cpu_va;
 	dmem->size = hp->size;
 	dmem->backing = DMAMEM_BACKING_HOSTMEM;
 	dmem->translator = DMAMEM_XLATE_LUT;

--- a/include/upcie/dmamem_memfd.h
+++ b/include/upcie/dmamem_memfd.h
@@ -113,6 +113,7 @@ dmamem_from_memfd(struct dmamem *dmem, struct iommufd *iommufd, size_t size, siz
 		UPCIE_DEBUG("FAILED: iommufd_ioas_map_file(); err(%d)", err);
 		goto err_munmap;
 	}
+	dmem->base_va = dmem->cpu_va;
 
 	return 0;
 

--- a/include/upcie/nvme/nvme_request.h
+++ b/include/upcie/nvme/nvme_request.h
@@ -441,7 +441,7 @@ nvme_request_prep_command_prps_contig_dmamem(struct nvme_request *request,
 	 * of a contiguous buffer. */
 	uint8_t *vbase = (uint8_t *)dbuf - page_off;
 	const uint64_t hp_off =
-		(uint64_t)(vbase - (uint8_t *)dmem->cpu_va) & (dmem->hugepgsz - 1);
+		(uint64_t)(vbase - (uint8_t *)dmem->base_va) & (dmem->hugepgsz - 1);
 	uint64_t strides_left = ((dmem->hugepgsz - hp_off) >> page_shift) - 1;
 	uint64_t page_phys = cmd->prp1 - page_off;
 

--- a/include/upcie/nvme/nvme_request.h
+++ b/include/upcie/nvme/nvme_request.h
@@ -392,20 +392,19 @@ nvme_request_prep_command_prps_iov(struct nvme_request *request, struct hostmem_
  *
  * @param request      NVMe request context; the PRP list is written
  *                     into request->prp with iova request->prp_addr.
- * @param heap         dmamem_heap that dbuf was carved from.
+ * @param dmem         dmamem describing the range dbuf lies in.
  * @param dbuf         Virtually contiguous data buffer.
  * @param dbuf_nbytes  Size of dbuf in bytes.
  * @param cmd          Command to populate prp1 (and prp2 / PRP list)
  *                     on.
  */
 static inline void
-nvme_request_prep_command_prps_contig_dmamem(struct nvme_request *request,
-					     struct dmamem_heap *heap, void *dbuf,
-					     size_t dbuf_nbytes, struct nvme_command *cmd)
+nvme_request_prep_command_prps_contig_dmamem(struct nvme_request *request, struct dmamem *dmem,
+					     void *dbuf, size_t dbuf_nbytes,
+					     struct nvme_command *cmd)
 {
 	const uint64_t pagesize = 4096;
 	const int page_shift = 12;
-	struct dmamem *dmem = heap->dmem;
 	const uint64_t page_off = (uintptr_t)dbuf & (pagesize - 1);
 	const uint64_t npages = (page_off + dbuf_nbytes + pagesize - 1) >> page_shift;
 
@@ -482,18 +481,17 @@ nvme_request_prep_command_prps_contig_dmamem(struct nvme_request *request,
  *   constructed.
  *
  * @param request   NVMe request context.
- * @param heap      dmamem_heap the iovec buffers were carved from.
+ * @param dmem      dmamem describing the range the iovec buffers lie in.
  * @param dvec      Array of iovec structures.
  * @param dvec_cnt  Element count of dvec.
  * @param cmd       Command to populate prp1 (and prp2 / PRP list) on.
  */
 static inline void
-nvme_request_prep_command_prps_iov_dmamem(struct nvme_request *request,
-					  struct dmamem_heap *heap, struct iovec *dvec,
-					  size_t dvec_cnt, struct nvme_command *cmd)
+nvme_request_prep_command_prps_iov_dmamem(struct nvme_request *request, struct dmamem *dmem,
+					  struct iovec *dvec, size_t dvec_cnt,
+					  struct nvme_command *cmd)
 {
 	const uint64_t pagesize = 4096;
-	struct dmamem *dmem = heap->dmem;
 	uint64_t *prp_list = request->prp;
 	size_t prp_idx = 0;
 

--- a/include/upcie/nvme/nvme_request_cuda.h
+++ b/include/upcie/nvme/nvme_request_cuda.h
@@ -45,64 +45,21 @@ nvme_request_prp_retranslate_cuda(struct cudamem_heap *heap, void *virt)
  * @param dbuf Pointer to the (virtually) contiguous data buffer to be described by PRPs.
  * @param dbuf_nbytes Size in bytes of the data buffer.
  * @param cmd Pointer to the NVMe command to be prepared with PRP entries.
+ *
+ * Builds a transient dmamem per call; hot paths should construct one once
+ * and call the _dmamem builder directly.
  */
 static inline void
 nvme_request_prep_command_prps_contig_cuda(struct nvme_request *request, struct cudamem_heap *heap,
                                            void *dbuf, size_t dbuf_nbytes, struct nvme_command *cmd)
 {
-	const uint64_t pagesize = heap->config->pagesize;
+	struct dmamem dmem;
 
-	cmd->prp1 = cudamem_heap_block_vtp(heap, dbuf);
-
-	/* Only PRP1 may carry a sub-page offset; the page count and every later
-	 * entry are measured from the page floor. ceil((off+nbytes)/pagesize). Take
-	 * the offset from the virtual address -- vtp preserves the sub-page offset --
-	 * so the page count and the npages == 1 branch do not wait on the vtp load. */
-	const uint64_t page_off = (uintptr_t)dbuf & (pagesize - 1);
-	const uint64_t npages =
-		(page_off + dbuf_nbytes + pagesize - 1) >> heap->config->pagesize_shift;
-
-	/* Chaining is not supported, thus assert that the given dbuf fits. */
-	assert(npages <= 1 + 512);
-
-	if (npages == 1) {
+	if (dmamem_from_cuda_lut(&dmem, heap)) {
 		return;
 	}
 
-	/* The heap is virtually contiguous but physically contiguous only within a
-	 * device page. Stride PRP entries physically from PRP1 while inside the same
-	 * device page and re-translate when the running address crosses a device-page
-	 * boundary. A buffer that fits within a single device page (the common case)
-	 * never crosses, so this reduces to the stride of a contiguous buffer. */
-	uint8_t *vbase = (uint8_t *)dbuf - page_off;
-	const uint64_t dp_off =
-		((uint64_t)vbase - heap->vaddr) & (heap->config->device_pagesize - 1);
-	uint64_t strides_left =
-		((heap->config->device_pagesize - dp_off) >> heap->config->pagesize_shift) - 1;
-	uint64_t page_phys = cmd->prp1 - page_off;
-
-	if (npages == 2) {
-		cmd->prp2 = strides_left
-				    ? page_phys + pagesize
-				    : nvme_request_prp_retranslate_cuda(heap, vbase + pagesize);
-		return;
-	}
-
-	uint64_t *prp_list = (uint64_t *)request->prp;
-
-	cmd->prp2 = request->prp_addr;
-	for (uint64_t i = 1; i < npages; ++i) {
-		if (strides_left) {
-			page_phys += pagesize;
-			strides_left--;
-		} else {
-			page_phys = nvme_request_prp_retranslate_cuda(
-				heap, vbase + (i << heap->config->pagesize_shift));
-			strides_left =
-				(heap->config->device_pagesize >> heap->config->pagesize_shift) - 1;
-		}
-		prp_list[i - 1] = page_phys;
-	}
+	nvme_request_prep_command_prps_contig_dmamem(request, &dmem, dbuf, dbuf_nbytes, cmd);
 }
 
 /**
@@ -123,41 +80,21 @@ nvme_request_prep_command_prps_contig_cuda(struct nvme_request *request, struct 
  * @param dvec Array of iovec structures describing the data segments.
  * @param dvec_cnt Number of elements in the dvec array.
  * @param cmd Pointer to the NVMe command to be prepared with PRP entries.
+ *
+ * Builds a transient dmamem per call; hot paths should construct one once
+ * and call the _dmamem builder directly.
  */
 static inline void
 nvme_request_prep_command_prps_iov_cuda(struct nvme_request *request, struct cudamem_heap *heap,
-				   	struct iovec *dvec, size_t dvec_cnt, struct nvme_command *cmd)
+                                        struct iovec *dvec, size_t dvec_cnt, struct nvme_command *cmd)
 {
-	const uint64_t pagesize = heap->config->pagesize;
-	uint64_t *prp_list = (uint64_t *)request->prp;
-	size_t prp_idx = 0;
+	struct dmamem dmem;
 
-	cmd->prp1 = cudamem_heap_block_vtp(heap, dvec[0].iov_base);
-
-	for (size_t i = 0; i < dvec_cnt; ++i) {
-		uint8_t *base = (uint8_t *)dvec[i].iov_base;
-		size_t remaining = dvec[i].iov_len;
-		size_t offset = 0;
-
-		/* Skip the first page of the first iovec — it is PRP1 */
-		if (i == 0) {
-			offset = pagesize;
-			remaining = (remaining > pagesize) ? remaining - pagesize : 0;
-		}
-
-		while (remaining > 0) {
-			prp_list[prp_idx++] = cudamem_heap_block_vtp(heap, base + offset);
-
-			offset += pagesize;
-			remaining = (remaining > pagesize) ? remaining - pagesize : 0;
-		}
+	if (dmamem_from_cuda_lut(&dmem, heap)) {
+		return;
 	}
 
-	if (prp_idx == 1) {
-		cmd->prp2 = prp_list[0];
-	} else if (prp_idx > 1) {
-		cmd->prp2 = request->prp_addr;
-	}
+	nvme_request_prep_command_prps_iov_dmamem(request, &dmem, dvec, dvec_cnt, cmd);
 }
 
 /**

--- a/include/upcie/nvme/nvme_request_hip.h
+++ b/include/upcie/nvme/nvme_request_hip.h
@@ -45,64 +45,21 @@ nvme_request_prp_retranslate_hip(struct hipmem_heap *heap, void *virt)
  * @param dbuf Pointer to the (virtually) contiguous data buffer to be described by PRPs.
  * @param dbuf_nbytes Size in bytes of the data buffer.
  * @param cmd Pointer to the NVMe command to be prepared with PRP entries.
+ *
+ * Builds a transient dmamem per call; hot paths should construct one once
+ * and call the _dmamem builder directly.
  */
 static inline void
 nvme_request_prep_command_prps_contig_hip(struct nvme_request *request, struct hipmem_heap *heap,
-                                           void *dbuf, size_t dbuf_nbytes, struct nvme_command *cmd)
+                                          void *dbuf, size_t dbuf_nbytes, struct nvme_command *cmd)
 {
-	const uint64_t pagesize = heap->config->pagesize;
+	struct dmamem dmem;
 
-	cmd->prp1 = hipmem_heap_block_vtp(heap, dbuf);
-
-	/* Only PRP1 may carry a sub-page offset; the page count and every later
-	 * entry are measured from the page floor. ceil((off+nbytes)/pagesize). Take
-	 * the offset from the virtual address -- vtp preserves the sub-page offset --
-	 * so the page count and the npages == 1 branch do not wait on the vtp load. */
-	const uint64_t page_off = (uintptr_t)dbuf & (pagesize - 1);
-	const uint64_t npages =
-		(page_off + dbuf_nbytes + pagesize - 1) >> heap->config->pagesize_shift;
-
-	/* Chaining is not supported, thus assert that the given dbuf fits. */
-	assert(npages <= 1 + 512);
-
-	if (npages == 1) {
+	if (dmamem_from_hip_lut(&dmem, heap)) {
 		return;
 	}
 
-	/* The heap is virtually contiguous but physically contiguous only within a
-	 * device page. Stride PRP entries physically from PRP1 while inside the same
-	 * device page and re-translate when the running address crosses a device-page
-	 * boundary. A buffer that fits within a single device page (the common case)
-	 * never crosses, so this reduces to the stride of a contiguous buffer. */
-	uint8_t *vbase = (uint8_t *)dbuf - page_off;
-	const uint64_t dp_off =
-		((uint64_t)vbase - heap->vaddr) & (heap->config->device_pagesize - 1);
-	uint64_t strides_left =
-		((heap->config->device_pagesize - dp_off) >> heap->config->pagesize_shift) - 1;
-	uint64_t page_phys = cmd->prp1 - page_off;
-
-	if (npages == 2) {
-		cmd->prp2 = strides_left
-				    ? page_phys + pagesize
-				    : nvme_request_prp_retranslate_hip(heap, vbase + pagesize);
-		return;
-	}
-
-	uint64_t *prp_list = (uint64_t *)request->prp;
-
-	cmd->prp2 = request->prp_addr;
-	for (uint64_t i = 1; i < npages; ++i) {
-		if (strides_left) {
-			page_phys += pagesize;
-			strides_left--;
-		} else {
-			page_phys = nvme_request_prp_retranslate_hip(
-				heap, vbase + (i << heap->config->pagesize_shift));
-			strides_left =
-				(heap->config->device_pagesize >> heap->config->pagesize_shift) - 1;
-		}
-		prp_list[i - 1] = page_phys;
-	}
+	nvme_request_prep_command_prps_contig_dmamem(request, &dmem, dbuf, dbuf_nbytes, cmd);
 }
 
 /**
@@ -123,41 +80,21 @@ nvme_request_prep_command_prps_contig_hip(struct nvme_request *request, struct h
  * @param dvec Array of iovec structures describing the data segments.
  * @param dvec_cnt Number of elements in the dvec array.
  * @param cmd Pointer to the NVMe command to be prepared with PRP entries.
+ *
+ * Builds a transient dmamem per call; hot paths should construct one once
+ * and call the _dmamem builder directly.
  */
 static inline void
 nvme_request_prep_command_prps_iov_hip(struct nvme_request *request, struct hipmem_heap *heap,
-				   	struct iovec *dvec, size_t dvec_cnt, struct nvme_command *cmd)
+                                       struct iovec *dvec, size_t dvec_cnt, struct nvme_command *cmd)
 {
-	const uint64_t pagesize = heap->config->pagesize;
-	uint64_t *prp_list = (uint64_t *)request->prp;
-	size_t prp_idx = 0;
+	struct dmamem dmem;
 
-	cmd->prp1 = hipmem_heap_block_vtp(heap, dvec[0].iov_base);
-
-	for (size_t i = 0; i < dvec_cnt; ++i) {
-		uint8_t *base = (uint8_t *)dvec[i].iov_base;
-		size_t remaining = dvec[i].iov_len;
-		size_t offset = 0;
-
-		/* Skip the first page of the first iovec — it is PRP1 */
-		if (i == 0) {
-			offset = pagesize;
-			remaining = (remaining > pagesize) ? remaining - pagesize : 0;
-		}
-
-		while (remaining > 0) {
-			prp_list[prp_idx++] = hipmem_heap_block_vtp(heap, base + offset);
-
-			offset += pagesize;
-			remaining = (remaining > pagesize) ? remaining - pagesize : 0;
-		}
+	if (dmamem_from_hip_lut(&dmem, heap)) {
+		return;
 	}
 
-	if (prp_idx == 1) {
-		cmd->prp2 = prp_list[0];
-	} else if (prp_idx > 1) {
-		cmd->prp2 = request->prp_addr;
-	}
+	nvme_request_prep_command_prps_iov_dmamem(request, &dmem, dvec, dvec_cnt, cmd);
 }
 
 /**


### PR DESCRIPTION
Unifies PRP construction so one builder serves any DMA source, leaving heap construction as the only thing that differs per vendor.

`struct dmamem` used `cpu_va` for two things: the base offsets are measured from, and whether the CPU may dereference the range. Those agree for host memory and cannot for device memory, so the GPU constructors left it NULL and `dmamem_va_to_iova` asserted on it, locking device buffers out of the generic path. This adds `base_va` for the arithmetic and leaves `cpu_va` meaning CPU-dereferenceable, so the builders can take a `dmamem` and the vendor entry points delegate instead of duplicating the page walk.

Verified by building the tree and checking that a LUT dmamem with `cpu_va == NULL` translates correctly. The CUDA and HIP headers are compiled by neither CI nor a machine without the toolkits, so both delegations were only type-checked against stubs.
