### PR TITLE
refactor(dmabuf)!: separate the experimental import path from the uPCIe API

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -91,6 +91,16 @@ jobs:
       run: |
         gcc -std=c11 -Wall -Wextra -Iinclude -c tests/test_vfioctl.c -o /tmp/test_vfioctl.o
 
+    # Compiling against the source tree says nothing about what is installed.
+    - name: Build a translation unit through the installed headers
+      run: |
+        meson install -C builddir --destdir /tmp/staged
+        prefix=$(meson introspect --buildoptions builddir \
+          | tr ',' '\n' | grep -A2 '"name": "prefix"' | grep '"value"' \
+          | sed 's/.*"value": "//; s/".*//')
+        gcc -std=c11 -Wall -Wextra -I"/tmp/staged${prefix}/include" \
+          -c tests/test_vfioctl.c -o /tmp/test_vfioctl_installed.o
+
   #
   # Provision a QEMU guest from the nosi image and run the test-suite, once with
   # the IOMMU disabled (uio_pci_generic) and once enabled (vfio-pci + iommufd).

--- a/docs/src/libraries.md
+++ b/docs/src/libraries.md
@@ -54,16 +54,24 @@ The descriptions below follow the bottom-up layering.
 ## dma-buf
 
 `dmabuf.h`
-: Helpers for working with dma-bufs. Resolves the physical pages behind a dma-buf
-  for raw-physical DMA and pretty-prints a dma-buf's layout. The dma-buf may
+: Represents a dma-buf and the physical pages behind it, segments those pages
+  into a LUT for raw-physical DMA, and pretty-prints the layout. The dma-buf may
   originate from host memory (memfd via udmabuf) or device memory such as CUDA.
+  This header needs nothing beyond libc.
 
-  Resolving physical pages (`dmabuf_attach`/`dmabuf_detach`) imports the dma-buf
-  through the out-of-tree `dmabuf_import` module, shipped as the
-  `dmabuf-import` DKMS package (see `experimental/dmabuf_import`). When its
-  UAPI header `<linux/dmabuf_import.h>` is absent these helpers compile as stubs
-  returning `ENOTSUP`, so uPCIe still builds without it; the module must also be
-  loaded at runtime for the import to succeed.
+`experimental/dmabuf_import.h`
+: **Experimental.** Resolves the DMA addresses behind a dma-buf
+  (`dmabuf_import_attach`/`dmabuf_import_detach`), which is what populates the
+  structure above. It imports the dma-buf through the out-of-tree
+  `dmabuf_import` module, shipped as the `dmabuf-import` DKMS package (see
+  `experimental/dmabuf_import`). When its UAPI header
+  `<linux/dmabuf_import.h>` is absent these helpers compile as stubs returning
+  `ENOTSUP` and `UPCIE_HAVE_DMABUF_IMPORT` is 0, so uPCIe still builds without
+  it; the module must also be loaded at runtime for the import to succeed.
+
+  The GPU memory helpers (`cudamem_heap.h`, `cudamem_mapping.h`,
+  `hipmem_heap.h`, `hipmem_mapping.h`) all reach their physical addresses
+  through this path, so they carry the same dependency.
 
 ## Umbrella
 

--- a/include/upcie/cudamem_heap.h
+++ b/include/upcie/cudamem_heap.h
@@ -6,6 +6,10 @@
  *
  * This heap implementation uses the CUDA driver to pre-allocate memory and
  * the dma-buf interface to get the physical addresses.
+ *
+ * EXPERIMENTAL dependency: the physical addresses come from the out-of-tree
+ * dmabuf-import DKMS module, see <upcie/experimental/dmabuf_import.h>.
+ *
  * While the heap memory is allocated on the GPU, the freelist is maintained in
  * host memory. This avoids segfaults at the cost of slower alloc/free.
  *
@@ -106,7 +110,7 @@ cudamem_heap_term(struct cudamem_heap *heap)
 		return;
 	}
 
-	dmabuf_detach(&heap->dmabuf);
+	dmabuf_import_detach(&heap->dmabuf);
 	cudamem_heap_empty_freelist(heap->freelist);
 	free(heap->phys_lut);
 	cuMemFree((CUdeviceptr)heap->vaddr);
@@ -166,9 +170,10 @@ cudamem_heap_init(struct cudamem_heap *heap, size_t size, struct cudamem_config 
 	heap->freelist->free = 1;
 	heap->freelist->next = NULL;
 
-	err = dmabuf_attach(dmabuf_fd, &heap->dmabuf);
+	/* NOTE: EXPERIMENTAL dependency, see <upcie/experimental/dmabuf_import.h> */
+	err = dmabuf_import_attach(dmabuf_fd, &heap->dmabuf);
 	if (err) {
-		UPCIE_DEBUG("FAILED: dmabuf_attach(), err: %d", err);
+		UPCIE_DEBUG("FAILED: dmabuf_import_attach(), err: %d", err);
 		goto error;
 	}
 
@@ -190,7 +195,7 @@ cudamem_heap_init(struct cudamem_heap *heap, size_t size, struct cudamem_config 
 	return 0;
 
 error_after_attach:
-	dmabuf_detach(&heap->dmabuf);
+	dmabuf_import_detach(&heap->dmabuf);
 	free(heap->freelist);
 	free(heap->phys_lut);
 	cuMemFree(vaddr);

--- a/include/upcie/cudamem_mapping.h
+++ b/include/upcie/cudamem_mapping.h
@@ -9,6 +9,9 @@
  * already allocated (via cuMemAlloc, cuMemCreate/cuMemMap, or cudaMalloc) and
  * builds a physical address LUT for them via the same dma-buf interface.
  *
+ * EXPERIMENTAL dependency: the physical addresses come from the out-of-tree
+ * dmabuf-import DKMS module, see <upcie/experimental/dmabuf_import.h>.
+ *
  * Chunk-cached design
  * -------------------
  *
@@ -23,7 +26,7 @@
  *
  * `_add` walks chunks intersecting the floored user range, ref-bumps existing
  * entries, and populates new entries via cuMemGetHandleForAddressRange +
- * dmabuf_attach + dmabuf_get_lut. `_remove` decrements rc and frees the dma-buf
+ * dmabuf_import_attach + dmabuf_get_lut. `_remove` decrements rc and frees the dma-buf
  * when rc reaches zero. Repeated overlapping registrations in the same chunk
  * amortize to one dma-buf cost, and resolve to identical phys for any VA they
  * share.
@@ -230,7 +233,7 @@ cudamem_mapping_chunk_deref(struct cudamem_mapping_registry *registry, size_t ch
 		}
 		cm->rc--;
 		if (cm->rc == 0) {
-			dmabuf_detach(&cm->attach);
+			dmabuf_import_detach(&cm->attach);
 			memset(&cm->attach, 0, sizeof(cm->attach));
 			registry->lut_phys[idx] = 0;
 		}
@@ -331,9 +334,10 @@ cudamem_mapping_chunk_populate(uint64_t *phys_base_out, struct dmabuf *attach_ou
 		goto err_free;
 	}
 
-	err = dmabuf_attach(dmabuf_fd, &attach);
+	/* NOTE: EXPERIMENTAL dependency, see <upcie/experimental/dmabuf_import.h> */
+	err = dmabuf_import_attach(dmabuf_fd, &attach);
 	if (err) {
-		UPCIE_DEBUG("FAILED: dmabuf_attach(), err: %d", err);
+		UPCIE_DEBUG("FAILED: dmabuf_import_attach(), err: %d", err);
 		close(dmabuf_fd);
 		goto err_free;
 	}
@@ -360,7 +364,7 @@ cudamem_mapping_chunk_populate(uint64_t *phys_base_out, struct dmabuf *attach_ou
 	return 0;
 
 err_detach:
-	dmabuf_detach(&attach);
+	dmabuf_import_detach(&attach);
 err_free:
 	free(tmp);
 	return err;

--- a/include/upcie/dmabuf.h
+++ b/include/upcie/dmabuf.h
@@ -1,35 +1,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 /**
- * Get physical addresses from a dma-buf
- * =====================================
+ * Representation of a dma-buf and its physical pages
+ * ==================================================
  *
- * This is a generic interface that is compatible with any dma-buf.
- * A dma-buf FD can be obtained either from host memory, memfd->udmabuf, or
- * device memory, e.g., CUDA or ROCm.
+ * A generic interface compatible with any dma-buf. A dma-buf descriptor can be
+ * obtained from host memory (memfd via udmabuf) or from device memory, e.g.
+ * CUDA or ROCm.
  *
- * NOTE: The import path uses the out-of-tree dmabuf_import module, which serves
- * its ioctls on /dev/dmabuf_import. Its UAPI is <linux/dmabuf_import.h>,
- * installed by the dmabuf-import DKMS package, which ships with the upcie
- * release as an asset but is versioned independently. That header is optional:
- * when it is not available, dmabuf_attach()/dmabuf_detach() compile as stubs
- * returning -ENOTSUP, so upcie builds and runs without the module (the import
- * calls simply fail). Install the package to enable the path; the module must
- * also be loaded at runtime.
+ * This header is dependency-free: it describes a dma-buf and segments its
+ * pages, and needs nothing beyond libc. Resolving the DMA addresses behind a
+ * dma-buf in the first place needs the out-of-tree dmabuf_import module and
+ * lives in <upcie/experimental/dmabuf_import.h>.
  *
  * @file dmabuf.h
  * @version 0.5.2
  */
-
-#include <linux/dma-buf.h>
-
-/* Optional: pull in the dmabuf_import UAPI if the DKMS package installed it.
- * Guarded with __has_include so upcie builds without it. */
-#if defined(__has_include)
-#  if __has_include(<linux/dmabuf_import.h>)
-#    include <linux/dmabuf_import.h>
-#  endif
-#endif
 
 struct dmabuf_page {
 	uint64_t addr;			///< Address of a page
@@ -102,125 +88,3 @@ dmabuf_get_lut(struct dmabuf *dmabuf, size_t nphys, uint64_t *phys_lut, uint64_t
 
 	return 0;
 }
-
-#ifdef DMABUF_IMPORT_ATTACH
-/**
- * Attach to dma-buf with given FD
- *
- * Populates the given dma-buf structure with information about the dma-buf.
- */
-static inline int
-dmabuf_attach(int dmabuf_fd, struct dmabuf *dmabuf)
-{
-	struct dmabuf_import_attach attach;
-	struct dmabuf_import_get_map *map = NULL;
-	int import_fd, err;
-	size_t map_size, pages_size;
-
-	import_fd = open(DMABUF_IMPORT_DEVPATH, O_RDWR);
-	if (import_fd < 0) {
-		err = -errno;
-		UPCIE_DEBUG("FAILED: open(%s), errno: %d", DMABUF_IMPORT_DEVPATH, err);
-		return err;
-	}
-
-	memset(&attach, 0, sizeof(attach));
-	attach.fd = dmabuf_fd;
-
-	err = ioctl(import_fd, DMABUF_IMPORT_ATTACH, &attach);
-	if (err) {
-		err = -errno;
-		UPCIE_DEBUG("FAILED: ioctl(DMABUF_IMPORT_ATTACH), errno: %d", err);
-		goto exit;
-	}
-
-	map_size = attach.count * sizeof(struct dmabuf_import_dma_map);
-	map = malloc(sizeof(struct dmabuf_import_get_map) + map_size);
-	if (!map) {
-		err = -errno;
-		UPCIE_DEBUG("FAILED: malloc(map), errno: %d", err);
-		ioctl(import_fd, DMABUF_IMPORT_DETACH, &dmabuf_fd);
-		goto exit;
-	}
-
-	memset(map, 0, sizeof(*map));
-	map->fd = dmabuf_fd;
-	map->count = attach.count;
-
-	err = ioctl(import_fd, DMABUF_IMPORT_GET_MAP, map);
-	if (err) {
-		err = -errno;
-		UPCIE_DEBUG("FAILED: ioctl(DMABUF_IMPORT_GET_MAP), errno: %d\n", err);
-		ioctl(import_fd, DMABUF_IMPORT_DETACH, &dmabuf_fd);
-		goto exit;
-	}
-
-	memset(dmabuf, 0, sizeof(*dmabuf));
-	dmabuf->fd = dmabuf_fd;
-	dmabuf->npages = map->count;
-	pages_size = sizeof(struct dmabuf_page) * dmabuf->npages;
-	dmabuf->pages = malloc(pages_size);
-	if (!dmabuf->pages) {
-		err = -errno;
-		UPCIE_DEBUG("FAILED: malloc(dmabuf->pages), errno: %d", err);
-		ioctl(import_fd, DMABUF_IMPORT_DETACH, &dmabuf_fd);
-		goto exit;
-	}
-
-	memcpy(dmabuf->pages, map->dma_arr, pages_size);
-
-exit:
-	free(map);
-	close(import_fd);
-	return err;
-}
-
-/**
- * Detach from given dma-buf
- *
- * NOTE: This doesn't free the underlying memory
- */
-static inline int
-dmabuf_detach(struct dmabuf *dmabuf)
-{
-	int import_fd, err;
-
-	free(dmabuf->pages);
-
-	import_fd = open(DMABUF_IMPORT_DEVPATH, O_RDWR);
-	if (import_fd < 0) {
-		err = -errno;
-		UPCIE_DEBUG("FAILED: open(%s), errno: %d", DMABUF_IMPORT_DEVPATH, err);
-		return err;
-	}
-
-	err = ioctl(import_fd, DMABUF_IMPORT_DETACH, &dmabuf->fd);
-	if (err) {
-		err = -errno;
-		UPCIE_DEBUG("FAILED: ioctl(DMABUF_IMPORT_DETACH), errno: %d\n", err);
-		// fall-through
-	}
-
-	close(dmabuf->fd);
-	close(import_fd);
-	return err;
-}
-#else /* !DMABUF_IMPORT_ATTACH: dmabuf-import UAPI unavailable, provide stubs */
-/**
- * Attach stub -- the dmabuf_import UAPI (<linux/dmabuf_import.h>) is not
- * available. Install the dmabuf-import DKMS package to enable importing.
- */
-static inline int
-dmabuf_attach(int UPCIE_UNUSED(dmabuf_fd), struct dmabuf *UPCIE_UNUSED(dmabuf))
-{
-	UPCIE_DEBUG("FAILED: dmabuf_import unavailable; install dmabuf-import-dkms");
-	return -ENOTSUP;
-}
-
-static inline int
-dmabuf_detach(struct dmabuf *UPCIE_UNUSED(dmabuf))
-{
-	UPCIE_DEBUG("FAILED: dmabuf_import unavailable; install dmabuf-import-dkms");
-	return -ENOTSUP;
-}
-#endif /* DMABUF_IMPORT_ATTACH */

--- a/include/upcie/dmamem_cuda.h
+++ b/include/upcie/dmamem_cuda.h
@@ -9,7 +9,7 @@
  * borrowing an already-populated cudamem_heap. The heap has already
  * done the heavy lifting: cuMemAlloc for the device VA range,
  * cuMemGetHandleForAddressRange to export the range as a dma-buf,
- * dmabuf_attach + dmabuf_get_lut to enumerate per-device-page PAs into
+ * dmabuf_import_attach + dmabuf_get_lut to enumerate per-device-page PAs into
  * heap->phys_lut. This constructor just points the LUT-translator
  * fields on struct dmamem at the already-populated table and marks the
  * dmamem as wrapping (owned=0) so destroy does not touch the heap's

--- a/include/upcie/dmamem_hip.h
+++ b/include/upcie/dmamem_hip.h
@@ -9,7 +9,7 @@
  * borrowing an already-populated hipmem_heap. The heap has already
  * called hipMalloc for the device VA range,
  * hipMemGetHandleForAddressRange to export as a dma-buf,
- * dmabuf_attach + dmabuf_get_lut to enumerate per-device-page PAs into
+ * dmabuf_import_attach + dmabuf_get_lut to enumerate per-device-page PAs into
  * heap->phys_lut. This constructor just points the LUT-translator
  * fields on struct dmamem at the already-populated table and marks the
  * dmamem as wrapping (owned=0) so destroy does not touch the heap's

--- a/include/upcie/experimental/dmabuf_import.h
+++ b/include/upcie/experimental/dmabuf_import.h
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+/**
+ * Resolve a dma-buf's DMA addresses via the dmabuf_import module
+ * ==============================================================
+ *
+ * ==========================================================================
+ * EXPERIMENTAL DEPENDENCY
+ * Requires the out-of-tree dmabuf-import DKMS module, which installs the UAPI
+ * as <linux/dmabuf_import.h> and serves /dev/dmabuf_import. Without the header
+ * these compile to stubs returning -ENOTSUP, so uPCIe still builds;
+ * UPCIE_HAVE_DMABUF_IMPORT tells you which case you got. The module must also
+ * be loaded at runtime.
+ * ==========================================================================
+ *
+ * @file dmabuf_import.h
+ * @version 0.5.2
+ */
+#ifndef UPCIE_EXPERIMENTAL_DMABUF_IMPORT_H
+#define UPCIE_EXPERIMENTAL_DMABUF_IMPORT_H
+
+/* Include <upcie/dmabuf.h> first for struct dmabuf; the uPCIe headers have no
+ * include guards, so it cannot be pulled in from here. <upcie/upcie.h> orders
+ * them correctly. */
+
+/* Optional: pull in the dmabuf_import UAPI if the DKMS package installed it.
+ * Guarded with __has_include so upcie builds without it. */
+#if defined(__has_include)
+#  if __has_include(<linux/dmabuf_import.h>)
+#    include <linux/dmabuf_import.h>
+#  endif
+#endif
+
+#ifdef DMABUF_IMPORT_ATTACH
+/* The module's UAPI is available, so the real import path is compiled in. */
+#define UPCIE_HAVE_DMABUF_IMPORT 1
+/**
+ * Attach to dma-buf with given FD
+ *
+ * Populates the given dma-buf structure with information about the dma-buf.
+ */
+static inline int
+dmabuf_import_attach(int dmabuf_fd, struct dmabuf *dmabuf)
+{
+	struct dmabuf_import_attach attach;
+	struct dmabuf_import_get_map *map = NULL;
+	int import_fd, err;
+	size_t map_size, pages_size;
+
+	import_fd = open(DMABUF_IMPORT_DEVPATH, O_RDWR);
+	if (import_fd < 0) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: open(%s), errno: %d", DMABUF_IMPORT_DEVPATH, err);
+		return err;
+	}
+
+	memset(&attach, 0, sizeof(attach));
+	attach.fd = dmabuf_fd;
+
+	err = ioctl(import_fd, DMABUF_IMPORT_ATTACH, &attach);
+	if (err) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: ioctl(DMABUF_IMPORT_ATTACH), errno: %d", err);
+		goto exit;
+	}
+
+	map_size = attach.count * sizeof(struct dmabuf_import_dma_map);
+	map = malloc(sizeof(struct dmabuf_import_get_map) + map_size);
+	if (!map) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: malloc(map), errno: %d", err);
+		ioctl(import_fd, DMABUF_IMPORT_DETACH, &dmabuf_fd);
+		goto exit;
+	}
+
+	memset(map, 0, sizeof(*map));
+	map->fd = dmabuf_fd;
+	map->count = attach.count;
+
+	err = ioctl(import_fd, DMABUF_IMPORT_GET_MAP, map);
+	if (err) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: ioctl(DMABUF_IMPORT_GET_MAP), errno: %d\n", err);
+		ioctl(import_fd, DMABUF_IMPORT_DETACH, &dmabuf_fd);
+		goto exit;
+	}
+
+	memset(dmabuf, 0, sizeof(*dmabuf));
+	dmabuf->fd = dmabuf_fd;
+	dmabuf->npages = map->count;
+	pages_size = sizeof(struct dmabuf_page) * dmabuf->npages;
+	dmabuf->pages = malloc(pages_size);
+	if (!dmabuf->pages) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: malloc(dmabuf->pages), errno: %d", err);
+		ioctl(import_fd, DMABUF_IMPORT_DETACH, &dmabuf_fd);
+		goto exit;
+	}
+
+	memcpy(dmabuf->pages, map->dma_arr, pages_size);
+
+exit:
+	free(map);
+	close(import_fd);
+	return err;
+}
+
+/**
+ * Detach from given dma-buf
+ *
+ * NOTE: This doesn't free the underlying memory
+ */
+static inline int
+dmabuf_import_detach(struct dmabuf *dmabuf)
+{
+	int import_fd, err;
+
+	free(dmabuf->pages);
+
+	import_fd = open(DMABUF_IMPORT_DEVPATH, O_RDWR);
+	if (import_fd < 0) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: open(%s), errno: %d", DMABUF_IMPORT_DEVPATH, err);
+		return err;
+	}
+
+	err = ioctl(import_fd, DMABUF_IMPORT_DETACH, &dmabuf->fd);
+	if (err) {
+		err = -errno;
+		UPCIE_DEBUG("FAILED: ioctl(DMABUF_IMPORT_DETACH), errno: %d\n", err);
+		// fall-through
+	}
+
+	close(dmabuf->fd);
+	close(import_fd);
+	return err;
+}
+#else /* !DMABUF_IMPORT_ATTACH: the module UAPI is unavailable, stub it out */
+/* The module's UAPI was not found, so the calls below fail with -ENOTSUP. */
+#define UPCIE_HAVE_DMABUF_IMPORT 0
+
+/**
+ * Attach stub: the dmabuf_import UAPI (<linux/dmabuf_import.h>) is not
+ * available. Install the dmabuf-import DKMS package to enable importing.
+ */
+static inline int
+dmabuf_import_attach(int UPCIE_UNUSED(dmabuf_fd), struct dmabuf *UPCIE_UNUSED(dmabuf))
+{
+	UPCIE_DEBUG("FAILED: dmabuf_import unavailable; install dmabuf-import-dkms");
+	return -ENOTSUP;
+}
+
+static inline int
+dmabuf_import_detach(struct dmabuf *UPCIE_UNUSED(dmabuf))
+{
+	UPCIE_DEBUG("FAILED: dmabuf_import unavailable; install dmabuf-import-dkms");
+	return -ENOTSUP;
+}
+#endif /* DMABUF_IMPORT_ATTACH */
+
+#endif /* UPCIE_EXPERIMENTAL_DMABUF_IMPORT_H */

--- a/include/upcie/hipmem_heap.h
+++ b/include/upcie/hipmem_heap.h
@@ -6,6 +6,10 @@
  *
  * This heap implementation uses the HIP/ROCm runtime to pre-allocate memory and
  * the dma-buf interface to get the physical addresses.
+ *
+ * EXPERIMENTAL dependency: the physical addresses come from the out-of-tree
+ * dmabuf-import DKMS module, see <upcie/experimental/dmabuf_import.h>.
+ *
  * While the heap memory is allocated on the GPU, the freelist is maintained in
  * host memory. This avoids segfaults at the cost of slower alloc/free.
  *
@@ -107,7 +111,7 @@ hipmem_heap_term(struct hipmem_heap *heap)
 		return;
 	}
 
-	dmabuf_detach(&heap->dmabuf);
+	dmabuf_import_detach(&heap->dmabuf);
 	hipmem_heap_empty_freelist(heap->freelist);
 	free(heap->phys_lut);
 	hipFree((void *)heap->vaddr);
@@ -175,9 +179,10 @@ hipmem_heap_init(struct hipmem_heap *heap, size_t size, struct hipmem_config *co
 	heap->freelist->free = 1;
 	heap->freelist->next = NULL;
 
-	err = dmabuf_attach(dmabuf_fd, &heap->dmabuf);
+	/* NOTE: EXPERIMENTAL dependency, see <upcie/experimental/dmabuf_import.h> */
+	err = dmabuf_import_attach(dmabuf_fd, &heap->dmabuf);
 	if (err) {
-		UPCIE_DEBUG("FAILED: dmabuf_attach(), err: %d", err);
+		UPCIE_DEBUG("FAILED: dmabuf_import_attach(), err: %d", err);
 		goto error;
 	}
 
@@ -199,7 +204,7 @@ hipmem_heap_init(struct hipmem_heap *heap, size_t size, struct hipmem_config *co
 	return 0;
 
 error_after_attach:
-	dmabuf_detach(&heap->dmabuf);
+	dmabuf_import_detach(&heap->dmabuf);
 	free(heap->freelist);
 	free(heap->phys_lut);
 	hipFree(vaddr);

--- a/include/upcie/hipmem_mapping.h
+++ b/include/upcie/hipmem_mapping.h
@@ -9,6 +9,9 @@
  * already allocated (via hipMalloc or hipMemCreate/hipMemMap) and builds a
  * physical address LUT for them via the same dma-buf interface.
  *
+ * EXPERIMENTAL dependency: the physical addresses come from the out-of-tree
+ * dmabuf-import DKMS module, see <upcie/experimental/dmabuf_import.h>.
+ *
  * Chunk-cached design
  * -------------------
  *
@@ -21,7 +24,7 @@
  *
  * `_add` walks chunks intersecting the floored user range, ref-bumps existing
  * entries, and populates new entries via hipMemGetHandleForAddressRange +
- * dmabuf_attach + dmabuf_get_lut. `_remove` decrements rc and frees the dma-buf
+ * dmabuf_import_attach + dmabuf_get_lut. `_remove` decrements rc and frees the dma-buf
  * when rc reaches zero. Repeated overlapping registrations in the same chunk
  * amortize to one dma-buf cost, and resolve to identical phys for any VA they
  * share.
@@ -229,7 +232,7 @@ hipmem_mapping_chunk_deref(struct hipmem_mapping_registry *registry, size_t chun
 		}
 		cm->rc--;
 		if (cm->rc == 0) {
-			dmabuf_detach(&cm->attach);
+			dmabuf_import_detach(&cm->attach);
 			memset(&cm->attach, 0, sizeof(cm->attach));
 			registry->lut_phys[idx] = 0;
 		}
@@ -330,9 +333,10 @@ hipmem_mapping_chunk_populate(uint64_t *phys_base_out, struct dmabuf *attach_out
 		goto err_free;
 	}
 
-	err = dmabuf_attach(dmabuf_fd, &attach);
+	/* NOTE: EXPERIMENTAL dependency, see <upcie/experimental/dmabuf_import.h> */
+	err = dmabuf_import_attach(dmabuf_fd, &attach);
 	if (err) {
-		UPCIE_DEBUG("FAILED: dmabuf_attach(), err: %d", err);
+		UPCIE_DEBUG("FAILED: dmabuf_import_attach(), err: %d", err);
 		close(dmabuf_fd);
 		goto err_free;
 	}
@@ -359,7 +363,7 @@ hipmem_mapping_chunk_populate(uint64_t *phys_base_out, struct dmabuf *attach_out
 	return 0;
 
 err_detach:
-	dmabuf_detach(&attach);
+	dmabuf_import_detach(&attach);
 err_free:
 	free(tmp);
 	return err;

--- a/include/upcie/upcie.h
+++ b/include/upcie/upcie.h
@@ -71,6 +71,9 @@ extern "C" {
 #include <upcie/barriers.h>
 #include <upcie/bitfield.h>
 #include <upcie/dmabuf.h>
+/* EXPERIMENTAL: needs the out-of-tree dmabuf-import DKMS module, and compiles
+ * to -ENOTSUP stubs without it. Must follow <upcie/dmabuf.h>. */
+#include <upcie/experimental/dmabuf_import.h>
 #include <upcie/hostmem.h>
 #include <upcie/hostmem_config.h>
 #include <upcie/hostmem_hugepage.h>

--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,7 @@ install_headers(
   [
     'include/upcie/barriers.h',
     'include/upcie/bitfield.h',
+    'include/upcie/debug.h',
     'include/upcie/cudamem_config.h',
     'include/upcie/cudamem_dma.h',
     'include/upcie/cudamem_heap.h',
@@ -54,21 +55,6 @@ install_headers(
     'include/upcie/hipmem_dma.h',
     'include/upcie/hipmem_heap.h',
     'include/upcie/hipmem_mapping.h',
-    'include/upcie/nvme/nvme_command.h',
-    'include/upcie/nvme/nvme_controller.h',
-    'include/upcie/nvme/nvme_controller_dmamem_type1.h',
-    'include/upcie/nvme/nvme_controller_dmamem_uio.h',
-    'include/upcie/nvme/nvme_controller_dmamem_vfio.h',
-    'include/upcie/nvme/nvme_controller_vfio.h',
-    'include/upcie/nvme/nvme_controller_vfio_pci.h',
-    'include/upcie/nvme/nvme_controller_cuda.h',
-    'include/upcie/nvme/nvme_mmio.h',
-    'include/upcie/nvme/nvme_qid.h',
-    'include/upcie/nvme/nvme_qpair.h',
-    'include/upcie/nvme/nvme_qpair_cuda.h',
-    'include/upcie/nvme/nvme_request.h',
-    'include/upcie/nvme/nvme_request_cuda.h',
-    'include/upcie/nvme/nvme_request_hip.h',
     'include/upcie/pci.h',
     'include/upcie/upcie.h',
     'include/upcie/upcie_cuda.h',
@@ -87,6 +73,29 @@ install_headers(
     'include/upcie/experimental/dmabuf_import.h',
   ],
   subdir: 'upcie/experimental'
+)
+
+# Same reason as above: install_headers() flattens, so the nvme/ headers need
+# their own call to keep the subdirectory that upcie.h includes them by.
+install_headers(
+  [
+    'include/upcie/nvme/nvme_command.h',
+    'include/upcie/nvme/nvme_controller.h',
+    'include/upcie/nvme/nvme_controller_dmamem_type1.h',
+    'include/upcie/nvme/nvme_controller_dmamem_uio.h',
+    'include/upcie/nvme/nvme_controller_dmamem_vfio.h',
+    'include/upcie/nvme/nvme_controller_vfio.h',
+    'include/upcie/nvme/nvme_controller_vfio_pci.h',
+    'include/upcie/nvme/nvme_controller_cuda.h',
+    'include/upcie/nvme/nvme_mmio.h',
+    'include/upcie/nvme/nvme_qid.h',
+    'include/upcie/nvme/nvme_qpair.h',
+    'include/upcie/nvme/nvme_qpair_cuda.h',
+    'include/upcie/nvme/nvme_request.h',
+    'include/upcie/nvme/nvme_request_cuda.h',
+    'include/upcie/nvme/nvme_request_hip.h',
+  ],
+  subdir: 'upcie/nvme'
 )
 
 # Optional dependency for other Meson projects

--- a/meson.build
+++ b/meson.build
@@ -78,6 +78,17 @@ install_headers(
   subdir: 'upcie'
 )
 
+# Separate call: install_headers() flattens its file list into one subdir, so a
+# header that must land in upcie/experimental/ cannot ride along with the list
+# above. upcie.h includes this one, so leaving it out breaks every installed
+# consumer.
+install_headers(
+  [
+    'include/upcie/experimental/dmabuf_import.h',
+  ],
+  subdir: 'upcie/experimental'
+)
+
 # Optional dependency for other Meson projects
 upcie_dep = declare_dependency(
   include_directories: include_directories('include')

--- a/tests/test_cudamem_dmabuf.c
+++ b/tests/test_cudamem_dmabuf.c
@@ -52,9 +52,9 @@ int main(void)
 		goto exit;
 	}
 
-	err = dmabuf_attach(dmabuf_fd, &dmabuf);
+	err = dmabuf_import_attach(dmabuf_fd, &dmabuf);
 	if (err) {
-		printf("# FAILED: dmabuf_attach(); err(%d)\n", err);
+		printf("# FAILED: dmabuf_import_attach(); err(%d)\n", err);
 		goto exit;
 	}
 
@@ -63,7 +63,7 @@ int main(void)
 	err = dmabuf_get_lut(&dmabuf, nphys, phys_lut, pagesize);
 	if (err) {
 		printf("# FAILED: dmabuf_get_lut(); err(%d)\n", err);
-		dmabuf_detach(&dmabuf);
+		dmabuf_import_detach(&dmabuf);
 		goto exit;
 	}
 
@@ -74,7 +74,7 @@ int main(void)
 		printf("  - 0x%" PRIx64 "\n", phys_lut[i]);
 	}
 
-	dmabuf_detach(&dmabuf);
+	dmabuf_import_detach(&dmabuf);
 
 exit:
 	cuMemFree(vaddr);

--- a/tests/test_hipmem_nvme_readwrite.c
+++ b/tests/test_hipmem_nvme_readwrite.c
@@ -9,9 +9,9 @@
  * controller (host-memory queues, CPU rings the doorbell), but the data buffers
  * are GPU VRAM allocated via hipmem, so the SSD DMAs straight to/from the GPU
  * over PCIe. Write a pattern host -> GPU -> SSD, read it back SSD -> GPU -> host,
- * and compare. Needs the dmabuf-import module (for dmabuf_attach's physical
- * LUT) and an IOMMU in passthrough (iommu=pt) so the NVMe DMAs to the GPU's
- * physical/P2P addresses directly.
+ * and compare. Needs the dmabuf-import module (for dmabuf_import_attach's
+ * physical LUT) and an IOMMU in passthrough (iommu=pt) so the NVMe DMAs to the
+ * GPU's physical/P2P addresses directly.
  */
 #define _UPCIE_WITH_NVME
 #include <upcie/upcie_hip.h>

--- a/tests/test_hipmem_producer.c
+++ b/tests/test_hipmem_producer.c
@@ -8,9 +8,9 @@
  * Exercises the AMD/HIP half of the hipmem backend without the dma-buf import
  * path: query the device config (HIP + BAR1) and allocate GPU memory, then
  * export it as a P2P dma-buf via HSA. This is the producer that hipmem_heap
- * feeds into dmabuf_attach()/dmabuf_get_lut(); the full heap additionally needs
- * the dmabuf-import kernel module, which this check deliberately avoids so it
- * runs on a stock ROCm install.
+ * feeds into dmabuf_import_attach()/dmabuf_get_lut(); the full heap
+ * additionally needs the dmabuf-import kernel module, which this check
+ * deliberately avoids so it runs on a stock ROCm install.
  */
 #include <upcie/upcie_hip.h>
 

--- a/tests/test_hostmem_dmabuf.c
+++ b/tests/test_hostmem_dmabuf.c
@@ -80,9 +80,9 @@ int main(void)
 		return err;
 	}
 
-	err = dmabuf_attach(dmabuf_fd, &dmabuf);
+	err = dmabuf_import_attach(dmabuf_fd, &dmabuf);
 	if (err) {
-		printf("# FAILED: dmabuf_attach(); err(%d)\n", err);
+		printf("# FAILED: dmabuf_import_attach(); err(%d)\n", err);
 		free(phys_lut);
 		return err;
 	}
@@ -103,7 +103,7 @@ int main(void)
 		printf("  - 0x%" PRIx64 "\n", phys_lut[i]);
 	}
 
-	dmabuf_detach(&dmabuf);
+	dmabuf_import_detach(&dmabuf);
 	free(phys_lut);
 	return 0;
 }


### PR DESCRIPTION
First of the v0.6.0 series, on `main`. #46 landed the rename this builds on.

`dmabuf.h` mixed a dma-buf representation that needs only libc with an import path that reaches an out-of-tree module and degrades to ENOTSUP stubs, and `upcie.h` pulls it in unconditionally, so the umbrella header carried that dependency without saying so. The import path moves to `<upcie/experimental/dmabuf_import.h>`, where the include line states the dependency and `UPCIE_HAVE_DMABUF_IMPORT` says which variant compiled.

The second commit is unrelated except that it is the same install list: `meson install` shipped an include tree that could not be compiled against, since `debug.h` was missing and the `nvme/` headers landed flattened. `verify.yml` now compiles the umbrella from an installed prefix, which fails on the parent commit and passes on this one; compiling against the source tree said nothing about what gets installed.

Both commits build, and both variants of the split header compile with the `UPCIE_HAVE_DMABUF_IMPORT` value each should produce.
