### PR TITLE
fix(nvme): keep queues from tearing across page boundaries

### DIFF
--- a/include/upcie/dmamem_heap.h
+++ b/include/upcie/dmamem_heap.h
@@ -110,22 +110,106 @@ dmamem_heap_term(struct dmamem_heap *heap)
 }
 
 /**
- * Allocate a sub-range of the heap with an explicit alignment.
- *
- * On success, *offset_out is the offset of the allocation within the
- * dmamem, aligned up to `alignment` bytes.
- *
- * @return 0 on success; -ENOMEM if the heap is full or fragmented past
- * the requested size; negative errno on input error.
+ * The span within which the heap can promise contiguous DMA addresses, or 0
+ * when the whole dmamem is one contiguous range.
+ */
+static inline size_t
+dmamem_heap_granule(struct dmamem_heap *heap)
+{
+	if (!heap || !heap->dmem || DMAMEM_XLATE_LUT != heap->dmem->translator) {
+		return 0;
+	}
+
+	return heap->dmem->hugepgsz;
+}
+
+/**
+ * Whether any single element would cross a granule boundary.
  */
 static inline int
-dmamem_heap_alloc_aligned(struct dmamem_heap *heap, size_t size, size_t alignment,
-			  size_t *offset_out)
+dmamem_heap_layout_tears(size_t start, size_t elem_count, size_t elem_size, size_t granule)
 {
-	struct dmamem_heap_block *b, *tail;
+	size_t i;
 
-	if (!heap || !size || !alignment || !offset_out) {
+	if (!granule) {
+		return 0;
+	}
+
+	/* Fits in one granule, or sits on a grid the granule divides evenly. */
+	if ((start & (granule - 1)) + (elem_count * elem_size) <= granule) {
+		return 0;
+	}
+	if (!(granule % elem_size) && !(start % elem_size)) {
+		return 0;
+	}
+
+	for (i = 0; i < elem_count; ++i) {
+		const size_t off = (start + (i * elem_size)) & (granule - 1);
+
+		if (off + elem_size > granule) {
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * Allocate elem_count elements of elem_size such that no single element
+ * crosses a granule boundary. The array itself may span granules.
+ *
+ * Ask for one element to get a region contiguous in device addresses.
+ *
+ * @return 0 on success; -ENOMEM if the heap is full or fragmented past the
+ * requested size; -EINVAL on input error, or when the promise is impossible,
+ * which is an element larger than a granule, or an array spanning granules
+ * whose element size does not divide one.
+ */
+static inline int
+dmamem_heap_alloc_array_aligned(struct dmamem_heap *heap, size_t elem_count, size_t elem_size,
+				size_t alignment, size_t *offset_out)
+{
+	const size_t granule = dmamem_heap_granule(heap);
+	struct dmamem_heap_block *b, *tail;
+	size_t size;
+
+	if (!heap || !elem_count || !elem_size || !alignment || !offset_out) {
 		return -EINVAL;
+	}
+	if (elem_count > SIZE_MAX / elem_size) {
+		return -EINVAL;
+	}
+
+	size = elem_count * elem_size;
+
+	/* Raising the alignment is what enforces the promise: on a grid the
+	 * granule divides evenly no element can straddle, and failing that the
+	 * whole array has to land inside one granule. */
+	if (granule) {
+		size_t required = alignment;
+
+		if (elem_size > granule) {
+			UPCIE_DEBUG("FAILED: elem_size(%zu) exceeds granule(%zu); no contiguity "
+				    "beyond a granule can be promised",
+				    elem_size, granule);
+			return -EINVAL;
+		} else if (!(granule % elem_size)) {
+			required = elem_size;
+		} else if (size <= granule) {
+			required = 1;
+			while (required < size) {
+				required <<= 1;
+			}
+		} else {
+			UPCIE_DEBUG("FAILED: elem_size(%zu) does not divide granule(%zu); an "
+				    "array spanning granules would tear",
+				    elem_size, granule);
+			return -EINVAL;
+		}
+
+		if (required > alignment) {
+			alignment = required;
+		}
 	}
 
 	for (b = heap->freelist; b; b = b->next) {
@@ -184,6 +268,9 @@ dmamem_heap_alloc_aligned(struct dmamem_heap *heap, size_t size, size_t alignmen
 
 		b->free = 0;
 		*offset_out = b->offset;
+
+		assert(!dmamem_heap_layout_tears(*offset_out, elem_count, elem_size, granule));
+
 		return 0;
 	}
 
@@ -191,11 +278,48 @@ dmamem_heap_alloc_aligned(struct dmamem_heap *heap, size_t size, size_t alignmen
 }
 
 /**
- * Allocate a sub-range of the heap using the heap's default alignment.
+ * Allocate an array using the heap's default alignment.
+ */
+static inline int
+dmamem_heap_alloc_array(struct dmamem_heap *heap, size_t elem_count, size_t elem_size,
+			size_t *offset_out)
+{
+	return dmamem_heap_alloc_array_aligned(heap, elem_count, elem_size, heap->alignment,
+					       offset_out);
+}
+
+/**
+ * Allocate a sub-range of the heap with an explicit alignment.
  *
- * Thin wrapper over dmamem_heap_alloc_aligned; use that directly for a
- * stricter constraint. On success, *offset_out is the offset of the
- * allocation within the dmamem.
+ * On success, *offset_out is the offset of the allocation within the
+ * dmamem, aligned up to `alignment` bytes.
+ *
+ * NOTE: The range is taken as an array of heap-alignment sized elements, so it
+ * may cross granule boundaries and is not necessarily contiguous in device
+ * addresses. Memory a device walks from a single base must come from
+ * dmamem_heap_alloc_array_aligned() instead.
+ *
+ * @return 0 on success; -ENOMEM if the heap is full or fragmented past
+ * the requested size; negative errno on input error.
+ */
+static inline int
+dmamem_heap_alloc_aligned(struct dmamem_heap *heap, size_t size, size_t alignment,
+			  size_t *offset_out)
+{
+	size_t elem_size, elem_count;
+
+	if (!heap || !size || !heap->alignment) {
+		return -EINVAL;
+	}
+
+	elem_size = heap->alignment;
+	elem_count = (size + elem_size - 1) / elem_size;
+
+	return dmamem_heap_alloc_array_aligned(heap, elem_count, elem_size, alignment, offset_out);
+}
+
+/**
+ * Allocate a sub-range of the heap using the heap's default alignment.
  *
  * @return 0 on success; -ENOMEM if the heap is full or fragmented past
  * the requested size; negative errno on input error.

--- a/include/upcie/nvme/nvme_controller_cuda.h
+++ b/include/upcie/nvme/nvme_controller_cuda.h
@@ -147,19 +147,20 @@ nvme_controller_cuda_create_io_qpair(struct nvme_controller *ctrlr,
 			return err;
 		}
 
-		_qpair.sq = cudamem_heap_block_alloc(heap, nbytes);
+		/* One element: the queue is created Physically Contiguous below. */
+		_qpair.sq = cudamem_dma_alloc_array(heap, 1, nbytes);
 		if (!_qpair.sq) {
 			err = -errno;
-			UPCIE_DEBUG("FAILED: cudamem_heap_block_alloc(sq); errno(%d)", err);
+			UPCIE_DEBUG("FAILED: cudamem_dma_alloc_array(sq); errno(%d)", err);
 			cuMemHostUnregister(_qpair.sqdb);
 			cuMemHostUnregister(_qpair.cqdb);
 			return err;
 		}
 
-		_qpair.cq = cudamem_heap_block_alloc(heap, nbytes);
+		_qpair.cq = cudamem_dma_alloc_array(heap, 1, nbytes);
 		if (!_qpair.cq) {
 			err = -errno;
-			UPCIE_DEBUG("FAILED: cudamem_heap_block_alloc(cq); errno(%d)", err);
+			UPCIE_DEBUG("FAILED: cudamem_dma_alloc_array(cq); errno(%d)", err);
 			cuMemHostUnregister(_qpair.sqdb);
 			cuMemHostUnregister(_qpair.cqdb);
 			cudamem_heap_block_free(heap, _qpair.sq);

--- a/include/upcie/nvme/nvme_controller_dmamem_vfio.h
+++ b/include/upcie/nvme/nvme_controller_dmamem_vfio.h
@@ -128,15 +128,16 @@ nvme_qpair_dmamem_init(struct nvme_qpair *qp, uint32_t qid, uint16_t depth, uint
 	qp->sqdb = bar0 + 0x1000 + ((2 * qid) << (2 + dstrd));
 	qp->cqdb = bar0 + 0x1000 + ((2 * qid + 1) << (2 + dstrd));
 
-	err = dmamem_heap_alloc_aligned(heap, queue_bytes, 4096, &sq_offset);
+	/* One element: the controller walks the queue from a single base. */
+	err = dmamem_heap_alloc_array_aligned(heap, 1, queue_bytes, 4096, &sq_offset);
 	if (err) {
-		UPCIE_DEBUG("FAILED: dmamem_heap_alloc_aligned(sq); err(%d)", err);
+		UPCIE_DEBUG("FAILED: dmamem_heap_alloc_array_aligned(sq); err(%d)", err);
 		return err;
 	}
 
-	err = dmamem_heap_alloc_aligned(heap, queue_bytes, 4096, &cq_offset);
+	err = dmamem_heap_alloc_array_aligned(heap, 1, queue_bytes, 4096, &cq_offset);
 	if (err) {
-		UPCIE_DEBUG("FAILED: dmamem_heap_alloc_aligned(cq); err(%d)", err);
+		UPCIE_DEBUG("FAILED: dmamem_heap_alloc_array_aligned(cq); err(%d)", err);
 		dmamem_heap_free(heap, sq_offset);
 		return err;
 	}

--- a/include/upcie/nvme/nvme_request.h
+++ b/include/upcie/nvme/nvme_request.h
@@ -130,10 +130,10 @@ nvme_request_pool_init_prps_dmamem(struct nvme_request_pool *pool, struct dmamem
 	uint8_t *prps_va;
 	int err;
 
-	err = dmamem_heap_alloc_aligned(heap, (size_t)NVME_REQUEST_POOL_LEN * pagesize, pagesize,
-					&prp_offset);
+	err = dmamem_heap_alloc_array_aligned(heap, NVME_REQUEST_POOL_LEN, pagesize, pagesize,
+					      &prp_offset);
 	if (err) {
-		UPCIE_DEBUG("FAILED: dmamem_heap_alloc_aligned(prps); err(%d)", err);
+		UPCIE_DEBUG("FAILED: dmamem_heap_alloc_array_aligned(prps); err(%d)", err);
 		return err;
 	}
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -13,6 +13,7 @@ test_sources = files(
   'test_dmamem_vfio_bar.c',
   'test_dmamem_nvme_vram.c',
   'test_dmamem_hostmem_lut.c',
+  'test_dmamem_heap.c',
 )
 
 incdir = include_directories('../include')

--- a/tests/test_dmamem_heap.c
+++ b/tests/test_dmamem_heap.c
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * Exercise the granule guarantee of dmamem_heap
+ * =============================================
+ *
+ * Pure allocator logic: the dmamem is a descriptor with a size and a
+ * translator, and only offsets are checked, so no device is needed.
+ */
+#define _UPCIE_WITH_NVME
+#include <upcie/upcie.h>
+
+#define HUGEPGSZ (2UL * 1024 * 1024)
+#define QUEUE_BYTES (1024UL * 64)
+#define PRP_BYTES (1024UL * 4096)
+
+static void
+heap_lut_init(struct dmamem *dmem, struct dmamem_heap *heap)
+{
+	memset(dmem, 0, sizeof(*dmem));
+	dmem->size = 512UL * 1024 * 1024;
+	dmem->translator = DMAMEM_XLATE_LUT;
+	dmem->hugepgsz = HUGEPGSZ;
+	dmem->hugepgsz_shift = 21;
+
+	assert(!dmamem_heap_init(heap, dmem, 4096));
+}
+
+static int
+straddles(size_t offset, size_t nbytes)
+{
+	return ((offset & (HUGEPGSZ - 1)) + nbytes) > HUGEPGSZ;
+}
+
+/**
+ * Replay the controller bring-up order, varying how many data buffers are
+ * taken from the same heap first; the buffers are what shift the queues off
+ * the grid that bring-up alone would keep them on.
+ */
+static int
+test_queues_never_straddle(void)
+{
+	for (size_t nbufs = 0; nbufs < 512; ++nbufs) {
+		struct dmamem_heap heap;
+		struct dmamem dmem;
+		size_t off;
+
+		heap_lut_init(&dmem, &heap);
+
+		assert(!dmamem_heap_alloc_array_aligned(&heap, 1, QUEUE_BYTES, 4096, &off));
+		assert(!dmamem_heap_alloc_array_aligned(&heap, 1, QUEUE_BYTES, 4096, &off));
+		assert(!dmamem_heap_alloc_array_aligned(&heap, NVME_REQUEST_POOL_LEN, 4096, 4096,
+						       &off));
+
+		for (size_t i = 0; i < nbufs; ++i) {
+			assert(!dmamem_heap_alloc_aligned(&heap, 4096, 4096, &off));
+		}
+
+		assert(!dmamem_heap_alloc_array_aligned(&heap, 1, QUEUE_BYTES, 4096, &off));
+		if (straddles(off, QUEUE_BYTES)) {
+			printf("FAILED: sq at 0x%zx straddles after %zu buffers\n", off, nbufs);
+			return 1;
+		}
+
+		assert(!dmamem_heap_alloc_array_aligned(&heap, 1, QUEUE_BYTES, 4096, &off));
+		if (straddles(off, QUEUE_BYTES)) {
+			printf("FAILED: cq at 0x%zx straddles after %zu buffers\n", off, nbufs);
+			return 1;
+		}
+
+		dmamem_heap_term(&heap);
+	}
+
+	printf("PASSED: queues stay within a granule across 512 layouts\n");
+	return 0;
+}
+
+/**
+ * Negative control: the unconstrained call may cross a boundary, and over
+ * the same layouts it does, so the guarantee above is not vacuous.
+ */
+static int
+test_plain_alloc_may_straddle(void)
+{
+	size_t crossings = 0;
+
+	for (size_t nbufs = 0; nbufs < 512; ++nbufs) {
+		struct dmamem_heap heap;
+		struct dmamem dmem;
+		size_t off;
+
+		heap_lut_init(&dmem, &heap);
+
+		assert(!dmamem_heap_alloc_aligned(&heap, QUEUE_BYTES, 4096, &off));
+		assert(!dmamem_heap_alloc_aligned(&heap, QUEUE_BYTES, 4096, &off));
+		assert(!dmamem_heap_alloc_aligned(&heap, PRP_BYTES, 4096, &off));
+
+		for (size_t i = 0; i < nbufs; ++i) {
+			assert(!dmamem_heap_alloc_aligned(&heap, 4096, 4096, &off));
+		}
+
+		assert(!dmamem_heap_alloc_aligned(&heap, QUEUE_BYTES, 4096, &off));
+		crossings += straddles(off, QUEUE_BYTES);
+
+		dmamem_heap_term(&heap);
+	}
+
+	if (!crossings) {
+		printf("FAILED: no layout crossed a boundary; the guarantee is untested\n");
+		return 1;
+	}
+
+	printf("PASSED: unconstrained allocation crosses boundaries (%zu of 512 layouts)\n",
+	       crossings);
+	return 0;
+}
+
+/**
+ * An array of pages may span granules; each page may not.
+ */
+static int
+test_array_elements_never_straddle(void)
+{
+	struct dmamem_heap heap;
+	struct dmamem dmem;
+	size_t off;
+
+	heap_lut_init(&dmem, &heap);
+
+	assert(!dmamem_heap_alloc_aligned(&heap, 4096 * 3, 4096, &off));
+	assert(!dmamem_heap_alloc_array_aligned(&heap, NVME_REQUEST_POOL_LEN, 4096, 4096, &off));
+
+	if (PRP_BYTES <= HUGEPGSZ) {
+		printf("FAILED: scratch no longer spans a granule; test says nothing\n");
+		return 1;
+	}
+
+	for (size_t i = 0; i < NVME_REQUEST_POOL_LEN; ++i) {
+		const size_t page = off + (i * 4096);
+
+		if (straddles(page, 4096)) {
+			printf("FAILED: scratch page %zu at 0x%zx straddles\n", i, page);
+			return 1;
+		}
+	}
+
+	dmamem_heap_term(&heap);
+
+	printf("PASSED: array spans granules, its elements do not\n");
+	return 0;
+}
+
+/**
+ * Asking for contiguity beyond a granule fails rather than tearing.
+ */
+static int
+test_impossible_requests_are_refused(void)
+{
+	struct dmamem_heap heap;
+	struct dmamem dmem;
+	size_t off;
+
+	heap_lut_init(&dmem, &heap);
+
+	if (-EINVAL != dmamem_heap_alloc_array_aligned(&heap, 1, HUGEPGSZ * 2, 4096, &off)) {
+		printf("FAILED: an element larger than a granule was accepted\n");
+		return 1;
+	}
+
+	/* 3 pages does not divide a granule: no untearing layout exists. */
+	if (-EINVAL != dmamem_heap_alloc_array_aligned(&heap, 4096, 4096 * 3, 4096, &off)) {
+		printf("FAILED: a tearing array layout was accepted\n");
+		return 1;
+	}
+
+	dmamem_heap_term(&heap);
+
+	printf("PASSED: impossible promises are refused\n");
+	return 0;
+}
+
+/**
+ * Under ARITHMETIC translation there is no granule to respect.
+ */
+static int
+test_arithmetic_is_unconstrained(void)
+{
+	struct dmamem_heap heap;
+	struct dmamem dmem;
+	size_t off;
+
+	memset(&dmem, 0, sizeof(dmem));
+	dmem.size = 512UL * 1024 * 1024;
+	dmem.translator = DMAMEM_XLATE_ARITHMETIC;
+
+	assert(!dmamem_heap_init(&heap, &dmem, 4096));
+
+	if (dmamem_heap_alloc_array_aligned(&heap, 1, HUGEPGSZ * 4, 4096, &off)) {
+		printf("FAILED: a contiguous IOVA range refused a large element\n");
+		return 1;
+	}
+
+	dmamem_heap_term(&heap);
+
+	printf("PASSED: arithmetic translation is unconstrained\n");
+	return 0;
+}
+
+int
+main(void)
+{
+	if (test_queues_never_straddle()) {
+		return 1;
+	}
+	if (test_plain_alloc_may_straddle()) {
+		return 1;
+	}
+	if (test_array_elements_never_straddle()) {
+		return 1;
+	}
+	if (test_impossible_requests_are_refused()) {
+		return 1;
+	}
+	if (test_arithmetic_is_unconstrained()) {
+		return 1;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Independent of the rename stack, on `main`.

A queue is handed to the controller as one base address it walks, but was allocated with a call that only promises alignment. Under the LUT translator a 64 KiB queue crossing a hugepage boundary continues onto physical pages belonging to something else. Nothing has hit it because every allocation during bring-up is a multiple of 64 KiB, which keeps offsets on a grid where that cannot happen; that is an accident of the sizes, and consumers sharing the heap between data buffers and queues, as the xNVMe backend does, break the grid as a matter of course.

The `hostmem_heap` this replaced handled it and said so at the call site, asking for the queue as `alloc_array(heap, 1, nbytes)`. The dmamem port kept the freelist and dropped that vocabulary, so the requirement silently became alignment-only. This restores it, and the CUDA controller turned out to have the same defect, so it gets the same fix. Plain allocation stays unconstrained on purpose: data buffers are re-translated per page on submit, so constraining them would pay fragmentation for nothing.

`tests/test_dmamem_heap.c` replays the bring-up order with varying buffer traffic and asserts no queue crosses, with a negative control asserting the unconstrained call still does, which it does in 15 of 512 layouts. Every other place a device receives a base address was checked and is already correct.
