### PR TITLE
fix(tests/cuda): run the kernels, and say so when they cannot

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,3 @@
 option('debug-logging', type: 'feature', value: 'auto')
+option('cuda-arch', type: 'string', value: 'native',
+       description: 'nvcc -arch for the GPU kernels; "native" targets the GPU in this machine')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -68,7 +68,7 @@ if cuda_dep.found()
                         '../include/upcie/nvme/nvme_command.h'),
     output: 'nvme_cuda_kernels.o',
     command: [
-      nvcc, '-c', '-arch=sm_75',
+      nvcc, '-c', '-arch=' + get_option('cuda-arch'),
       '-I', meson.project_source_root() / 'include',
       '-include', meson.project_build_root() / 'upcie_config.h',
       '@INPUT@', '-o', '@OUTPUT@',

--- a/tests/nvme_cuda_kernels.cu
+++ b/tests/nvme_cuda_kernels.cu
@@ -71,6 +71,17 @@ extern "C" cudaError_t
 nvme_io_launch(struct nvme_qpair_cuda **qps, struct nvme_command *cmds, int *results,
 	       uint32_t num_ios, unsigned int grid, unsigned int block)
 {
+	cudaError_t err;
+
 	nvme_io<<<grid, block>>>(qps, cmds, results, num_ios);
+
+	// A kernel that never launched leaves nothing to synchronize on, so
+	// cudaDeviceSynchronize() reports success; the launch itself is only
+	// reported here.
+	err = cudaGetLastError();
+	if (err != cudaSuccess) {
+		return err;
+	}
+
 	return cudaDeviceSynchronize();
 }


### PR DESCRIPTION
## Environment

A development box with an NVIDIA RTX A6000, which is compute capability 8.6, running driver 580.159.03. That driver carries CUDA 13.0, while the CUDA toolkit installed for building is 13.3. The NVMe under test sits at `0000:01:00.0` bound to `uio_pci_generic`. Nothing about that combination is exotic: a toolkit newer than the driver is what you get from installing a current toolkit next to a distribution driver, and a GPU newer than the arch these tests were pinned to is now the common case.

## What happened

`test_cuda_nvme_readwrite` failed with `FAILED: LBA 0 byte 1: expected 0x01 got 0x00`, which reads like a DMA or PRP problem. It is neither. The kernel never ran, and the test compared data it had never written.

Two defects, one hiding the other. `nvme_io_launch()` returned only `cudaDeviceSynchronize()`, but a kernel that fails to launch leaves nothing to synchronize on, so that call reports success and the launch error stays behind in `cudaGetLastError()`. Underneath it, the kernels were built for `sm_75` alone, so on the 8.6 GPU above the driver had to JIT the embedded PTX, and a 13.3 toolkit emits PTX that a 13.0 driver refuses outright with error 222.

## Worth a careful look

Whether `native` is the right default for the new `cuda-arch` option. It suits building and running on the same machine, which is what these tests do, but it will not suit cross-building or shipping a fat object, which is why it is an option rather than a fixed value.

## Verified

On the box described above, the default now passes from one queue at depth 1 up to four queues at depth 32 with 256 IOs. Rebuilt deliberately with `-Dcuda-arch=sm_75`, it fails immediately with `FAILED: nvme_io_launch(); cudaError_t(222)` rather than the misleading byte mismatch, so the masking is gone in both directions.

Not verified on any other GPU, driver or toolkit combination. There is no HIP counterpart to test: the HIP side of the tree has no device kernels, only host-side tests linked against the HIP runtime, so neither defect has an equivalent there.

This also likely explains the standing report that the GPU-initiated reap breaks at queue depth 8 and above; depths 8, 16 and 32 all pass now.

