### PR TITLE
fix(cijoe): load the dma-buf importer, which no longer rides on udmabuf

### DIFF
--- a/cijoe/tasks/cudamem_nvme.yaml
+++ b/cijoe/tasks/cudamem_nvme.yaml
@@ -12,7 +12,11 @@ steps:
 - name: drivers
   run: |
     modprobe uio_pci_generic || true
+    # Stock udmabuf is usually built in, so a failure here is not fatal.
     modprobe udmabuf || true
+    # Required: without /dev/dmabuf_import the run fails later with a
+    # confusing ENOENT from dmabuf_import_attach().
+    modprobe dmabuf_import
 
 - name: bind_uio
   run: |

--- a/cijoe/tasks/deploy.yaml
+++ b/cijoe/tasks/deploy.yaml
@@ -51,6 +51,8 @@ steps:
     modprobe iommufd || true
     modprobe vfio-pci || true
     modprobe udmabuf || true
+    # Non-fatal: only the GPU-direct tasks need it, and they load it themselves.
+    modprobe dmabuf_import || true
 
 - name: hugepages
   run: |

--- a/cijoe/tasks/hipmem_nvme.yaml
+++ b/cijoe/tasks/hipmem_nvme.yaml
@@ -12,7 +12,11 @@ steps:
 - name: drivers
   run: |
     modprobe uio_pci_generic || true
+    # Stock udmabuf is usually built in, so a failure here is not fatal.
     modprobe udmabuf || true
+    # Required: without /dev/dmabuf_import the run fails later with a
+    # confusing ENOENT from dmabuf_import_attach().
+    modprobe dmabuf_import
 
 - name: bind_uio
   run: |


### PR DESCRIPTION
The importer module was renamed in #46, so the cijoe tasks that bring a machine up still load the old one. Without `/dev/dmabuf_import` present, a run does not fail at setup; it fails later inside `dmabuf_import_attach()` with an ENOENT that says nothing about a missing module.

Part of the v0.6.0 series; sits directly on #48.
