### PR TITLE
fix(tests/dmamem): give the VRAM test an admin heap it fits in

### DIFF
--- a/tests/test_dmamem_nvme_vram.c
+++ b/tests/test_dmamem_nvme_vram.c
@@ -148,8 +148,9 @@ main(int argc, char *argv[])
 	       ", cpu bar view=%p size=%zu\n",
 	       gpu_bar_dmem.base_iova, (uint64_t)gpu_bar_dmem.size, gpu_bar_va, gpu_bar_va_size);
 
-	/* Small hugepage-backed dmamem for the NVMe admin queue backing. */
-	err = dmamem_from_memfd(&admin_dmem, &iommufd, 2ULL * 1024 * 1024, 2ULL * 1024 * 1024);
+	/* Hugepage-backed dmamem for the NVMe admin queue backing; the per-request
+	 * PRP scratch alone is NVME_REQUEST_POOL_LEN pages. */
+	err = dmamem_from_memfd(&admin_dmem, &iommufd, 16ULL * 1024 * 1024, 2ULL * 1024 * 1024);
 	if (err) {
 		fprintf(stderr, "FAIL: dmamem_from_memfd(admin) err(%d)\n", err);
 		goto out_gpu;


### PR DESCRIPTION
## What is broken

`test_dmamem_nvme_vram` builds a 2 MiB dmamem for the admin queue pair, but 7c9ae32 later gave the queue pair per-request PRP scratch of `NVME_REQUEST_POOL_LEN` pages, 4 MiB on its own. The allocation has failed with `-ENOMEM` ever since, so the test has never reached the DMA it exists to prove. It has been dead on main since 5 July.

## Worth a look

Whether 16 MiB is the size you want. The requirement is 4 MiB of PRP scratch plus the two queues, so 8 MiB would also do; I took headroom on the grounds that this is a test and the backing is hugepages.

## Verified

On an AMD Radeon RX 7800 XT (gfx1101) with a Samsung 9100 PRO, both bound to vfio-pci and sharing one iommufd IOAS, with the GPU BAR imported via `VFIO_DEVICE_FEATURE_DMA_BUF`:

```
gpu BAR imported: base_iova=0xff000000 size=0x400000000
VRAM peek: SN='...' MN='Samsung SSD 9100 PRO 2TB'
OK: NVMe DMAed IDENTIFY response into GPU VRAM through iommufd IOAS
OK: NVMe WRITE from VRAM round-tripped through LBA 0 (device read GPU memory over PCIe)
```

Both peer directions, so the controller writes into VRAM and reads out of it. Not verified on NVIDIA, where the same test should work but was not run.
