### PR TITLE
ci(dmabuf_import): follow the header split in the consumer check

### DIFF
--- a/.github/workflows/dmabuf-import-dkms.yml
+++ b/.github/workflows/dmabuf-import-dkms.yml
@@ -109,13 +109,17 @@ jobs:
           #include <inttypes.h>
           #define UPCIE_DEBUG(...) do { } while (0)
           #include <upcie/dmabuf.h>
+          #include <upcie/experimental/dmabuf_import.h>
+          #if !UPCIE_HAVE_DMABUF_IMPORT
+          #error "the installed prerequisite did not provide the UAPI"
+          #endif
           int main(void) {
                   struct dmabuf d = {0};
-                  int err = dmabuf_attach(-1, &d);
+                  int err = dmabuf_import_attach(-1, &d);
 
                   (void)DMABUF_IMPORT_DEVPATH;
                   if (err == -ENOTSUP) {
-                          fprintf(stderr, "dmabuf.h compiled its stubs\n");
+                          fprintf(stderr, "the import path compiled its stubs\n");
                           return 1;
                   }
                   return 0;


### PR DESCRIPTION
`main` is red: `dmabuf-import-dkms` fails in `install (24.04)` and `install (26.04)` with `implicit declaration of function 'dmabuf_attach'` and `'DMABUF_IMPORT_DEVPATH' undeclared`.

The consumer built against the installed deb still reached for the import path through `<upcie/dmabuf.h>`. #48 moved it to `<upcie/experimental/dmabuf_import.h>` and renamed the entry point to `dmabuf_import_attach()`, and this check was not carried along.

It survived review because the workflow is path-filtered on pull requests, to `experimental/dmabuf_import/**` and its own file. #48 touched neither, so it never ran there and first executed on the push to `main`. That trade-off is described in the workflow's own header comment; the filter is still right, but it means changes to the uPCIe-side API can break this check without any PR showing it.

The assertion on `UPCIE_HAVE_DMABUF_IMPORT` is new. Without it a consumer that quietly compiles the stubs would pass the build and only fail at runtime, which is the failure mode this job exists to catch.

Verified by reproducing the CI compile locally in both directions: it builds with the UAPI present, and fails with the `#error` when it is absent.
