### PR TITLE
Count the queue ids in use, and size the bitmap for every qid the checks admit

### DIFF
--- a/include/upcie/nvme/nvme_qid.h
+++ b/include/upcie/nvme/nvme_qid.h
@@ -25,7 +25,7 @@
 #define BITS_PER_WORD 64
 
 #define NVME_QID_MAX 0xFFFF
-#define NVME_QID_BITMAP_WORDS (NVME_QID_MAX / BITS_PER_WORD)
+#define NVME_QID_BITMAP_WORDS ((NVME_QID_MAX + BITS_PER_WORD - 1) / BITS_PER_WORD)
 
 static inline int
 nvme_qid_is_allocated(uint64_t *qid_bitmap, uint16_t qid)

--- a/include/upcie/nvme/nvme_qid.h
+++ b/include/upcie/nvme/nvme_qid.h
@@ -61,6 +61,26 @@ nvme_qid_alloc(uint64_t *qid_bitmap, uint16_t qid)
 	return 0;
 }
 
+/**
+ * Count the allocated queue ids, admin queue included
+ */
+static inline uint32_t
+nvme_qid_used(const uint64_t *qid_bitmap)
+{
+	uint32_t used = 0;
+
+	for (int word = 0; word < NVME_QID_BITMAP_WORDS; ++word) {
+		uint64_t w = qid_bitmap[word];
+
+		while (w) {
+			w &= w - 1;
+			used++;
+		}
+	}
+
+	return used;
+}
+
 static inline int
 nvme_qid_bitmap_init(uint64_t *qid_bitmap)
 {

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -14,6 +14,7 @@ test_sources = files(
   'test_dmamem_nvme_vram.c',
   'test_dmamem_hostmem_lut.c',
   'test_dmamem_heap.c',
+  'test_nvme_qid.c',
 )
 
 incdir = include_directories('../include')

--- a/tests/test_nvme_qid.c
+++ b/tests/test_nvme_qid.c
@@ -86,6 +86,41 @@ test_used_counts_across_words(void)
 }
 
 static int
+test_every_admitted_qid_is_representable(void)
+{
+	uint64_t bitmap[NVME_QID_BITMAP_WORDS + 1];
+
+	/* The bounds checks admit qid < NVME_QID_MAX, so the bitmap has to hold
+	 * every one of them. Truncating the word count instead of rounding up
+	 * leaves the top of that range indexing past the end.
+	 *
+	 * The guard word is zero rather than a pattern: allocating only ever
+	 * sets a bit, so any write lands in a word that should have stayed
+	 * clear, whereas a pattern can already carry the bit being set. */
+	assert(!nvme_qid_bitmap_init(bitmap));
+	bitmap[NVME_QID_BITMAP_WORDS] = 0;
+
+	if (nvme_qid_alloc(bitmap, NVME_QID_MAX - 1)) {
+		printf("FAILED: the highest admitted qid was refused\n");
+		return 1;
+	}
+
+	if (bitmap[NVME_QID_BITMAP_WORDS]) {
+		printf("FAILED: allocating qid %u wrote past the end of the bitmap\n",
+		       NVME_QID_MAX - 1);
+		return 1;
+	}
+
+	if (nvme_qid_used(bitmap) != 2) {
+		printf("FAILED: the highest admitted qid was not counted\n");
+		return 1;
+	}
+
+	printf("PASSED: every admitted qid is representable\n");
+	return 0;
+}
+
+static int
 test_allocating_twice_counts_once(void)
 {
 	uint64_t bitmap[NVME_QID_BITMAP_WORDS];
@@ -113,6 +148,9 @@ main(void)
 		return 1;
 	}
 	if (test_used_counts_across_words()) {
+		return 1;
+	}
+	if (test_every_admitted_qid_is_representable()) {
 		return 1;
 	}
 	if (test_allocating_twice_counts_once()) {

--- a/tests/test_nvme_qid.c
+++ b/tests/test_nvme_qid.c
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * Exercise the qid bitmap accounting
+ * ==================================
+ *
+ * Pure bitmap logic: the allocator is a bitmap and a handful of index
+ * calculations, so no device is needed.
+ */
+#define _UPCIE_WITH_NVME
+#include <upcie/upcie.h>
+
+static int
+test_init_reserves_the_admin_queue(void)
+{
+	uint64_t bitmap[NVME_QID_BITMAP_WORDS];
+
+	assert(!nvme_qid_bitmap_init(bitmap));
+
+	if (nvme_qid_used(bitmap) != 1) {
+		printf("FAILED: a freshly initialised bitmap should hold qid 0 alone\n");
+		return 1;
+	}
+
+	printf("PASSED: init reserves the admin queue\n");
+	return 0;
+}
+
+static int
+test_used_tracks_alloc_and_free(void)
+{
+	uint64_t bitmap[NVME_QID_BITMAP_WORDS];
+
+	assert(!nvme_qid_bitmap_init(bitmap));
+
+	for (uint16_t qid = 1; qid <= 8; ++qid) {
+		assert(!nvme_qid_alloc(bitmap, qid));
+
+		/* The admin queue is counted too, so the total runs one ahead */
+		if (nvme_qid_used(bitmap) != (uint32_t)qid + 1) {
+			printf("FAILED: after allocating %u ids, used is %u\n", qid,
+			       nvme_qid_used(bitmap));
+			return 1;
+		}
+	}
+
+	for (uint16_t qid = 8; qid >= 1; --qid) {
+		assert(!nvme_qid_free(bitmap, qid));
+
+		if (nvme_qid_used(bitmap) != (uint32_t)qid) {
+			printf("FAILED: after freeing down to %u, used is %u\n", qid,
+			       nvme_qid_used(bitmap));
+			return 1;
+		}
+	}
+
+	printf("PASSED: used tracks alloc and free\n");
+	return 0;
+}
+
+static int
+test_used_counts_across_words(void)
+{
+	uint64_t bitmap[NVME_QID_BITMAP_WORDS];
+	const uint16_t qids[] = {1, 63, 64, 65, 127, 128, 1023, 1024};
+	uint32_t expect = 1; ///< The admin queue
+
+	assert(!nvme_qid_bitmap_init(bitmap));
+
+	/* Straddling word boundaries is where an index calculation goes wrong
+	 * without the count noticing, so place ids either side of several. */
+	for (size_t i = 0; i < sizeof(qids) / sizeof(qids[0]); ++i) {
+		assert(!nvme_qid_alloc(bitmap, qids[i]));
+		expect++;
+
+		if (nvme_qid_used(bitmap) != expect) {
+			printf("FAILED: qid %u brought used to %u, expected %u\n", qids[i],
+			       nvme_qid_used(bitmap), expect);
+			return 1;
+		}
+	}
+
+	printf("PASSED: used counts across word boundaries\n");
+	return 0;
+}
+
+static int
+test_allocating_twice_counts_once(void)
+{
+	uint64_t bitmap[NVME_QID_BITMAP_WORDS];
+
+	assert(!nvme_qid_bitmap_init(bitmap));
+	assert(!nvme_qid_alloc(bitmap, 7));
+	assert(!nvme_qid_alloc(bitmap, 7));
+
+	if (nvme_qid_used(bitmap) != 2) {
+		printf("FAILED: allocating the same id twice counted %u\n", nvme_qid_used(bitmap));
+		return 1;
+	}
+
+	printf("PASSED: allocating the same id twice counts once\n");
+	return 0;
+}
+
+int
+main(void)
+{
+	if (test_init_reserves_the_admin_queue()) {
+		return 1;
+	}
+	if (test_used_tracks_alloc_and_free()) {
+		return 1;
+	}
+	if (test_used_counts_across_words()) {
+		return 1;
+	}
+	if (test_allocating_twice_counts_once()) {
+		return 1;
+	}
+
+	return 0;
+}

--- a/tests/test_nvme_qid.py
+++ b/tests/test_nvme_qid.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+def test_nvme_qid(cijoe):
+    """
+    Run the qid bitmap accounting checks.
+
+    Pure bitmap logic, so unlike the rest of the suite this needs no device and
+    runs wherever uPCIe is deployed.
+    """
+
+    binary = "test_nvme_qid"
+
+    err, _ = cijoe.run(f"which {binary}")
+    if err:
+        pytest.skip(f"{binary} is not installed on the target")
+
+    err, _ = cijoe.run(binary)
+    assert not err


### PR DESCRIPTION
Adds `nvme_qid_used()`, which xNVMe needs in order to report how many I/O queue
pairs a multi-process runtime has handed out, and fixes an out-of-bounds access
that writing the test for it exposed.

## What to look at

**The fix is the part worth reading.** `NVME_QID_BITMAP_WORDS` truncated rather
than rounding up, so at the default `NVME_QID_MAX` of `0xFFFF` the bitmap held
1023 words and covered qid 0 through 65471, while every bounds check admits
`qid < NVME_QID_MAX`. Qids 65472 through 65534 therefore passed the check and
indexed word 1023 of an array with indices 0 through 1022.

Nothing in tree reaches it, since `nvme_qid_find_free()` only scans the words
that exist and is where callers get their qid, so this is latent rather than
live. Reduced configurations are unaffected where `NVME_QID_MAX` is a multiple
of the word size, which both examples in the header docstring are; it is the
default that divides unevenly.

**The counting helper** sits with the other bitmap operations because it reads
the same representation. It counts the admin queue along with the I/O queues,
which the caller has to subtract; that is stated in its comment, and the
alternative of special-casing qid 0 seemed worse than saying so.

**The test is wired into the suite rather than only built.** The C test
binaries here are built and installed but not otherwise run by `verify`, so
`tests/test_nvme_qid.py` invokes this one, following the shape of
`test_cuda_nvme_readwrite.py`. It is the module's first test and needs no
device.

## Verification

CI now runs on this PR, and the new test is wired into the pytest suite rather
than only built, so the bitmap fix is covered there.

What CI cannot show is that the series bisects: run by hand, the feature
commit's cases pass against the unfixed bitmap and the boundary case fails
without the fix and passes with it.

Not exercised: other platforms, and the device tests, since nothing here
touches a device.
