### PR TITLE
ci: run on pull requests whatever they target

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,7 +6,6 @@ on:
     branches: [main]
     tags: ['v*']
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
Both workflows filtered `pull_request` on `branches: [main]`, so a pull request
targeting anything else got no checks at all. That is every pull request in a
stack after the first: #59 targets #58's branch and #60 targets #59's, and
neither showed a single check. Both were verified by dispatching `verify` by
hand, which is a weaker guarantee than the same runs arriving automatically,
and one nobody will remember to repeat.

Dropping the filter runs them wherever a pull request points. The `push`
trigger keeps its filter, so the only new runs are one per stacked pull
request.

Worth deciding rather than assuming: this also means a pull request opened
against a long-lived topic branch gets the full matrix, including the
self-hosted jobs. If that is unwanted, the alternative is to name the branches
explicitly, but that needs editing on every new stack.


## Verification

Demonstrated rather than argued: after restacking so this sits at the bottom,
#58, #59 and #60 all began reporting checks automatically, where #59 and #60
previously showed none at all.
