### PR TITLE
Probing tools: what the runtimes and the kernel actually do

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -107,3 +107,4 @@ upcie_dep = declare_dependency(
 subdir('example')
 subdir('tests')
 subdir('experimental')
+subdir('tools')

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,92 @@
+# Probing tools
+
+Small standalone binaries that report what a runtime or the kernel actually
+does. They differ from `tests/` in intent: a test asserts that behaviour is
+what uPCIe requires, a probe finds out what the behaviour is. Probes print and
+exit zero; they do not fail when the answer is inconvenient.
+
+They build with the rest of the project, each only where its dependency is
+present, so the CUDA probe appears on a machine with the CUDA driver and the
+HIP one on a machine with ROCm.
+
+## upcie_probe_dmabuf_{cuda,hip}
+
+Asks what a GPU runtime returns when told to export a device address range as
+a dma-buf, which is the mechanism uPCIe translates VRAM addresses through.
+Needs the out-of-tree `dmabuf-import` module from `experimental/`, since
+reading the scatter list of an imported dma-buf is not something mainline
+exposes to userspace.
+
+Per range it prints the segment count, how many bytes those segments describe
+against how many were requested, the shortest segment, the number of maximal
+physically contiguous runs, and the largest power-of-two granule the list can
+be indexed by. Then it asks whether the allocation a pointer falls in can be
+recovered from the pointer.
+
+The questions it was written to settle:
+
+1. Does the export describe the requested range, or something else?
+2. Is a sub-range at a non-zero offset described from that offset?
+3. What granule is the memory really contiguous at, as opposed to the
+   `alloc_granularity` the runtime reports?
+4. Can a registration recover the allocation a caller's pointer belongs to?
+
+### Findings
+
+Measured 2026-08-20, both hosts Ubuntu 26.04, Linux 7.0.0-28-generic.
+NVIDIA RTX A6000, driver 580.173.02, CUDA driver API 13000. AMD Radeon RX 7800
+XT (Navi 32), HIP driver 70152801. Two 64 MiB allocations per run.
+
+The `alloc_granularity` the runtimes report, 2 MiB on NVIDIA and 4096 on AMD,
+describes neither the export nor the physical layout.
+
+**CUDA honours the request.** A 4 KiB export describes exactly 4096 bytes; a
+2 MiB export exactly 2 MiB; a 3 MiB export exactly 3 MiB. An export at
+`base + 4K` starts at the physical address of `base + 4K`, not of `base`.
+Segments come back at `device_pagesize`, 64 KiB, so the whole allocation
+arrives as 1024 of them, but the addresses are adjacent: every range probed was
+a single contiguous physical run, the full 64 MiB included.
+
+**AMD ignores the request.** Every export, 4 KiB through 64 MiB, at base or at
+any offset, returned the same scatter list describing the whole underlying
+buffer object. Asked for 4096 bytes, it described 67108864, and the first
+segment was the base of the allocation whatever offset was asked for. The two
+allocations produced different lists, 6 runs and 16, so the export is
+per-allocation. Every run was a multiple of 4 MiB, and the shortest segment
+seen was 4 MiB.
+
+So `hipMemGetHandleForAddressRange` is, on this stack, a whole-object export
+whose range arguments are accepted and discarded.
+
+**Both recover the allocation from a pointer.** `cuMemGetAddressRange` and
+`hipMemGetAddressRange` returned the exact base and size for a pointer at the
+base, at `base + 3M + 4K`, and at the last byte.
+
+### What this means for translation
+
+Exporting once per chunk of a registered region cannot work on AMD, because
+each chunk export re-exports the entire object. The export has to happen once
+per allocation, with the scatter list indexed by offset from the allocation
+base, and the base recovered with `hipMemGetAddressRange` rather than assumed
+to be the pointer the caller passed. That shape is correct on CUDA too, which
+makes it the one to build.
+
+Getting it wrong is silent rather than loud. A caller registering at
+`base + 2M` and trusting the first segment address receives the physical
+address of `base`, and the DMA lands 2 MiB away from where it should. Checking
+the described length against the requested length, as `dmabuf_get_lut()` does,
+turns that into `-EINVAL` instead, which is the only reason this surfaced as an
+error rather than as corruption.
+
+A 2 MiB translation granule is supported on both, and for different reasons:
+on CUDA because the allocations were contiguous well past 2 MiB, on AMD because
+no physical run was shorter than 4 MiB. It is worth noting what that rests on,
+which is two allocations on one part per vendor. It also does not by itself fix
+anything on AMD, since a 2 MiB request at a 2 MiB offset is discarded like any
+other; the fix is the per-allocation export, and the granule is a separate
+choice on top of it.
+
+Nor does a granule have to become an alignment requirement on callers. Once the
+allocation base is recovered, the offset of a caller's pointer within it is
+known exactly, so registration can accept any pointer the vendor recognises and
+leave alignment to what NVMe PRP construction needs.

--- a/tools/README.md
+++ b/tools/README.md
@@ -10,6 +10,70 @@ present, so the CUDA probe appears on a machine with the CUDA driver and the
 HIP one on a machine with ROCm.
 
 ## upcie_probe_dmabuf_{cuda,hip}
+## upcie_probe_vfio_bar_import_{cuda,hip}
+
+Asks whether a GPU runtime will import another device's MMIO as a dma-buf and
+hand back a device pointer.
+
+`VFIO_DEVICE_FEATURE_DMA_BUF` exports a slice of a BAR as a dma-buf, and that
+descriptor has no CPU mapping: `test_dmamem_vfio_bar` reports
+`cpu_va=unavailable`. So a process holding only the descriptor cannot produce a
+host address, and `cuMemHostRegister()` with `CU_MEMHOSTREGISTER_IOMEMORY`,
+which is how the GPU-initiated NVMe path reaches a doorbell, has nothing to
+register. The remaining route is for the runtime to import the descriptor
+itself.
+
+The probe binds the device, exports a slice, imports it through
+`cuImportExternalMemory` or `hipImportExternalMemory`, maps it, and reads the
+first two dwords back from the device side. It reads rather than writes and
+defaults to offset 0, so what it touches is `CAP` and not a doorbell; the host
+reads the same register through its own mapping and the two are printed side by
+side. Equal values are the whole result.
+
+The question it was written to settle: can MMIO be delegated to a process that
+never holds the device fd? If the import fails, delegating a controller's
+doorbells means delegating the controller.
+
+Usage: `upcie_probe_vfio_bar_import_cuda <cdev> [region] [offset] [length]`,
+for example `upcie_probe_vfio_bar_import_cuda /dev/vfio/devices/vfio8 0 0
+0x1000`.
+
+### Findings
+
+Measured 2026-08-24, both hosts Linux 7.0.0-28-generic, against a Samsung NVMe
+controller bound to `vfio-pci`, BAR0 at offset 0 for 4 KiB. warp: NVIDIA RTX
+A6000, driver 580.173.02 (the open modules, `Dual MIT/GPL`), CUDA 13.3. wave:
+AMD Radeon RX 7800 XT with ROCm.
+
+Neither runtime takes it, and on NVIDIA the reason is not the one the probe was
+written to find:
+
+    CUDA   self-import (control)  CUDA_ERROR_NOT_SUPPORTED(801)
+           import(DMABUF_FD)      CUDA_ERROR_NOT_SUPPORTED(801)
+           import(OPAQUE_FD)      CUDA_ERROR_UNKNOWN(999)
+    HIP    hipImportExternalMemory=hipErrorOutOfMemory(2)
+
+The control allocates GPU memory, exports it with
+`cuMemGetHandleForAddressRange`, and imports that back. It fails identically, so
+`cuImportExternalMemory` with `CU_EXTERNAL_MEMORY_HANDLE_TYPE_DMABUF_FD` is
+unsupported on this stack for any exporter, and says nothing about vfio. The
+export direction works; only the import is refused. Nothing appears in the
+kernel log while it happens, and the open modules' importer,
+`nv_dma_import_from_fd()` in `nvidia/nv-dmabuf.c`, prints on both of its failure
+paths, which suggests the refusal is above the open layer.
+
+HIP has no dma-buf handle type at all: `hipExternalMemoryHandleType` stops at
+`NvSciBuf`, so `OpaqueFd` was the only thing to ask for.
+
+The export side is sound in both cases: `EXPORT_DMA_BUF` succeeds, and the host
+reads `0x28033fff` for `CAP` through its own mapping.
+
+So MMIO cannot be handed to a process as a descriptor today. A process that
+must ring a doorbell has to hold the device fd, map the BAR itself, and register
+the host address with `cuMemHostRegister(CU_MEMHOSTREGISTER_IOMEMORY)`, which is
+what the GPU-initiated path already does.
+
+## upcie_probe_dmabuf_{cuda,hip}
 
 Asks what a GPU runtime returns when told to export a device address range as
 a dma-buf, which is the mechanism uPCIe translates VRAM addresses through.

--- a/tools/README.md
+++ b/tools/README.md
@@ -12,6 +12,28 @@ HIP one on a machine with ROCm.
 ## upcie_probe_dmabuf_{cuda,hip}
 ## upcie_probe_vfio_bar_import_{cuda,hip}
 ## upcie_probe_vfio_share_gpu_cuda
+## upcie_probe_vram_ioas_{cuda,hip}
+
+Asks whether GPU memory can enter an iommufd IOAS, which is what a controller
+behind an IOMMU would have to DMA against.
+
+Under `uio_pci_generic` a controller consumes physical addresses and reaches a
+GPU allocation through its dma-buf scatter list. Under `vfio-pci` it consumes
+IOVAs, so the allocation has to be mapped with `IOMMU_IOAS_MAP_FILE`.
+`iommufd.h` records that as of 6.19 that call accepts only dma-bufs exported by
+vfio-pci and rejects those exported by CUDA or HIP. The probe asks the running
+kernel rather than trusting the comment, and maps a `memfd` first as a control,
+since a `MAP_FILE` that refuses everything would say nothing about GPU memory in
+particular.
+
+The question it was written to settle: can a controller under an IOMMU DMA into
+VRAM at all? That sits upstream of every question about sharing one controller
+between processes, because it decides whether GPU consumers can use `vfio-pci`
+in the first place.
+
+Usage: `upcie_probe_vram_ioas_cuda`, no arguments.
+
+## upcie_probe_vfio_share_gpu_cuda
 
 Asks whether a process that holds nothing but a passed vfio device fd can reach
 the BAR from a GPU kernel.

--- a/tools/README.md
+++ b/tools/README.md
@@ -66,6 +66,64 @@ the accounting argument for one of them does not survive the first finding
 above.
 
 ## upcie_probe_vram_ioas_{cuda,hip}
+## upcie_probe_vfio_cdev
+
+Asks whether a second process can claim a device another process already holds,
+which is the question any design for sharing a controller has to answer first.
+
+    upcie_probe_vfio_cdev <cdev> <attach:0|1> <hold-seconds>
+
+Run it while a primary holds the device and works normally. `open()` on the
+character device succeeds, which is what makes an independent second path look
+feasible, and that is as far as it gets:
+
+    --- SECOND, bind only:
+      open(cdev)                   ok
+      BIND_IOMMUFD                 Invalid argument
+      GET_REGION_INFO(BAR0)        Invalid argument
+
+A device cannot be bound to more than one `iommufd_ctx`, so
+`VFIO_DEVICE_BIND_IOMMUFD` fails, and since the UAPI header states the user is
+restricted from accessing the device before binding completes, everything after
+it fails too. No region info means no BAR, which means no doorbell. Offering a
+different iommufd does not help and neither does declining to attach.
+
+Note what does succeed in that second process: opening `/dev/iommu`, allocating
+an IOAS, and mapping memory into it. That is the trap, because the result is a
+valid-looking address space attached to no device.
+
+## upcie_probe_vfio_share
+
+Asks whether a privileged primary can delegate a device to an unprivileged
+secondary, and how far the delegation reaches. This is the same question
+`upcie_probe_vfio_delegate` asks about accounting and lifetime, put instead
+about privilege.
+
+    upcie_probe_vfio_share primary   <cdev> <sock>
+    upcie_probe_vfio_share secondary <sock>
+
+The primary binds the device, maps a memfd into its IOAS, then passes the
+device fd, the iommufd and the memfd over a unix socket. The secondary must be
+run as an ordinary user for the answer to mean anything, since dropping root
+inside one process is not the same test.
+
+    [secondary uid=1000]
+      recv fds                       ok
+      GET_REGION_INFO(BAR0)          ok
+      mmap(BAR0)                     ok
+      NVMe CAP low dword             0x28033fff   (secondary)
+      shared DMA buffer              wrote 0x00c0ffee
+      IOAS_MAP own buffer            ok
+        -> iova                      0x400000
+
+Three things follow. The secondary reaches the BAR and therefore the doorbells.
+It shares DMA memory through a memfd neither process had to name in the
+filesystem. And it registers memory of its own choosing through the passed
+iommufd, so it is not restricted to buffers the primary arranged in advance.
+Reading the same `CAP` value the primary reads is what confirms it is genuinely
+looking at the controller's registers.
+
+## upcie_probe_vram_ioas_{cuda,hip}
 
 Asks whether GPU memory can enter an iommufd IOAS, which is what a controller
 behind an IOMMU would have to DMA against.

--- a/tools/README.md
+++ b/tools/README.md
@@ -58,6 +58,13 @@ seen was 4 MiB.
 So `hipMemGetHandleForAddressRange` is, on this stack, a whole-object export
 whose range arguments are accepted and discarded.
 
+**An odd-sized allocation is reported unrounded, but backed differently.**
+Asked for 3 MiB + 4 KiB, both runtimes reported the size back as exactly
+3149824. CUDA's export described exactly that many bytes, ending in a 4 KiB
+segment; AMD's described 4194304, the whole 4 MiB object, which is more than
+the size it had just reported. So the size a runtime reports bounds neither the
+export below nor above in general.
+
 **Both recover the allocation from a pointer.** `cuMemGetAddressRange` and
 `hipMemGetAddressRange` returned the exact base and size for a pointer at the
 base, at `base + 3M + 4K`, and at the last byte.
@@ -85,6 +92,13 @@ which is two allocations on one part per vendor. It also does not by itself fix
 anything on AMD, since a 2 MiB request at a 2 MiB offset is discarded like any
 other; the fix is the per-allocation export, and the granule is a separate
 choice on top of it.
+
+It also means a LUT at a chosen granule cannot be filled by asking
+`dmabuf_get_lut()` for `ceil(size / granule)` entries, since that is a length
+mismatch on CUDA whenever the allocation does not end on a granule boundary.
+Walking the scatter list directly handles the short final granule, and lets the
+walk verify contiguity within each granule as it goes, which is what turns a
+whole-object mismatch into an error rather than a wrong address.
 
 Nor does a granule have to become an alignment requirement on callers. Once the
 allocation base is recovered, the offset of a caller's pointer within it is

--- a/tools/README.md
+++ b/tools/README.md
@@ -11,6 +11,81 @@ HIP one on a machine with ROCm.
 
 ## upcie_probe_dmabuf_{cuda,hip}
 ## upcie_probe_vfio_bar_import_{cuda,hip}
+## upcie_probe_vfio_share_gpu_cuda
+
+Asks whether a process that holds nothing but a passed vfio device fd can reach
+the BAR from a GPU kernel.
+
+Passing the descriptor over `SCM_RIGHTS` and mapping BAR0 in the receiver is
+known to work. What that leaves untested is the step the GPU-initiated NVMe
+path depends on: `cuMemHostRegister()` with `CU_MEMHOSTREGISTER_IOMEMORY` on a
+window of the received mapping, and an SM reaching it. The read comes from a
+kernel rather than from `cuMemcpyDtoH()`, because the copy engine is not what
+rings a doorbell.
+
+It is two processes rather than a fork with a `setuid()` in it, because
+dropping privilege is not the same state as never having had it: the dropped
+process keeps the supplementary groups it started with unless they are cleared,
+and a uid change clears the dumpable flag, either of which could be what a
+refusal is really about. So the secondary is started separately, as whatever
+user starts it, and the two meet over a named socket. It reads `CAP` rather
+than writing a doorbell, so it disturbs nothing, and both sides print what they
+read.
+
+Usage, with the primary in the background since it serves one secondary and
+leaves when it disconnects:
+
+    upcie_probe_vfio_share_gpu_cuda primary /dev/vfio/devices/vfio8 /tmp/probe.sock &
+    setpriv --reuid=1000 --regid=1000 --clear-groups \
+        upcie_probe_vfio_share_gpu_cuda secondary /tmp/probe.sock
+
+### Findings
+
+Measured 2026-08-24 on Linux 7.0.0-28-generic, NVIDIA RTX A6000 with driver
+580.173.02 and CUDA 13.3, against a Samsung NVMe controller bound to
+`vfio-pci`, reading `CAP` at BAR0 offset 0. Two runs against the same primary,
+differing only in who starts the secondary.
+
+A passed descriptor is enough, and privilege decides how far it goes. Started
+as root, the secondary gets all the way, and the SM reads what the primary
+reads:
+
+    [secondary] running as                   uid=0 euid=0 gid=0
+    [secondary] recv device fd               ok
+    [secondary] host read                    0x28033fff 0x08000030
+    [secondary] cuMemHostRegister(IOMEMORY)  ok
+    [secondary] kernel read                  0x28033fff 0x08000030
+
+Started as uid 1000, with `setpriv --reuid=1000 --regid=1000 --clear-groups` so
+that it never held privilege and carries no inherited groups, it receives the
+descriptor, maps BAR0 and reads the same register, then stops:
+
+    [secondary] running as                   uid=1000 euid=1000 gid=1000
+    [secondary] cuMemHostRegister(IOMEMORY)  CUDA_ERROR_NOT_PERMITTED
+
+The `standalone` mode is the control for that, opening the device itself with
+no delegation anywhere. With the cdev and `/dev/iommu` chowned to the user, an
+unprivileged process binds, attaches, maps BAR0 and reads the same register,
+and is refused in the same place:
+
+    [standalone] running as                   uid=1000 euid=1000 gid=1000
+    [standalone] bind and attach              ok
+    [standalone] host read                    0x28033fff 0x08000030
+    [standalone] cuMemHostRegister(IOMEMORY)  CUDA_ERROR_NOT_PERMITTED
+
+while the same binary as root reads `CAP` from a kernel. So the descriptor
+delegates the device, and `CU_MEMHOSTREGISTER_IOMEMORY` delegates nothing: it
+wants privilege of the calling process, and passing a descriptor has nothing to
+do with it. An unprivileged process can drive a controller from the CPU, its
+own or a delegated one, since ringing a doorbell from the host is an ordinary
+store into a mapping it already has. It cannot submit from a GPU kernel either
+way. Which capability short of root suffices was not tested.
+
+Worth noting in passing, since it is the model libvirt uses and it is now
+measured here: an unprivileged process can own a vfio device end to end when
+udev gives it the nodes.
+
+## upcie_probe_vfio_bar_import_{cuda,hip}
 
 Asks whether a GPU runtime will import another device's MMIO as a dma-buf and
 hand back a device pointer.

--- a/tools/README.md
+++ b/tools/README.md
@@ -13,6 +13,59 @@ HIP one on a machine with ROCm.
 ## upcie_probe_vfio_bar_import_{cuda,hip}
 ## upcie_probe_vfio_share_gpu_cuda
 ## upcie_probe_vram_ioas_{cuda,hip}
+## upcie_probe_vfio_delegate
+
+Asks two questions a design for sharing a controller has to answer, neither of
+which is about GPUs.
+
+**Which way registration goes.** A secondary holding the iommufd maps its own
+memory, which pins pages against the secondary. A secondary that instead sends
+a descriptor and asks the primary to map it pins them against the primary. The
+probe does both, in that order, and prints `RLIMIT_MEMLOCK` on each side, so
+running either side under a lowered limit shows which one it bounds.
+
+**What survives the primary.** The primary exits after serving. The secondary
+then re-reads a register through its own mapping of BAR0 and tries a further
+mapping through the iommufd it was handed. A device fd keeps the device bound;
+whether the address space outlives the process that created it is what a
+restart policy turns on.
+
+Usage, primary in the background since it serves one secondary and exits:
+
+    upcie_probe_vfio_delegate primary /dev/vfio/devices/vfio8 /tmp/d.sock &
+    upcie_probe_vfio_delegate secondary /tmp/d.sock
+    sh -c 'ulimit -l 64; upcie_probe_vfio_delegate secondary /tmp/d.sock'
+
+### Findings
+
+Measured 2026-08-24 on Linux 7.0.0-28-generic, a Samsung NVMe controller bound
+to `vfio-pci`, 2 MiB per mapping.
+
+**RLIMIT_MEMLOCK bounds none of it.** With the limit at 64 KiB on the
+secondary, and separately on the primary, every mapping still succeeded: the
+secondary's own `MAP_FILE` of a memfd, its `IOMMU_IOAS_MAP` of anonymous
+memory, and the primary's `MAP_FILE` on its behalf. So which side is "charged"
+is not a question this limit answers, and an unprivileged secondary does not
+need its limit raised to register memory.
+
+**The address space outlives the primary.** After the primary exits, closing
+its device fd and its iommufd, the secondary still reads `CAP` through its own
+mapping of BAR0 and still maps new memory through the iommufd it was handed:
+
+    [secondary] primary is gone                ok
+    [secondary] host read after                0x28033fff
+    [secondary] map after, via passed fd       ok, iova=0x800000
+
+The descriptors a secondary holds keep both the device and the IOAS alive, so a
+secondary is not obliged to die with the process that handed them over.
+
+**Both registration directions work.** The secondary can map its own memory
+through the passed iommufd, and the primary can map a descriptor the secondary
+sends. Nothing in the kernel prefers one; the choice is a design decision, and
+the accounting argument for one of them does not survive the first finding
+above.
+
+## upcie_probe_vram_ioas_{cuda,hip}
 
 Asks whether GPU memory can enter an iommufd IOAS, which is what a controller
 behind an IOMMU would have to DMA against.

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -1,0 +1,35 @@
+# Probing tools: small standalone binaries that report what a runtime or the
+# kernel actually does, as opposed to tests, which assert what it should do.
+# They are built only where their dependency is present.
+
+incdir = include_directories('../include', '.')
+
+cuda_dep = dependency(
+  'cuda', modules: ['cuda'],
+  required: false,
+)
+
+if cuda_dep.found()
+  executable(
+    'upcie_probe_dmabuf_cuda',
+    files('upcie_probe_dmabuf_cuda.c'),
+    include_directories: incdir,
+    dependencies: [cuda_dep],
+    install: true,
+  )
+endif
+
+cc = meson.get_compiler('c')
+hip_lib = cc.find_library('amdhip64', required: false)
+hip_hdr = cc.has_header('hip/hip_runtime_api.h', args: '-D__HIP_PLATFORM_AMD__')
+
+if hip_lib.found() and hip_hdr
+  executable(
+    'upcie_probe_dmabuf_hip',
+    files('upcie_probe_dmabuf_hip.c'),
+    include_directories: incdir,
+    dependencies: [hip_lib],
+    c_args: ['-D__HIP_PLATFORM_AMD__'],
+    install: true,
+  )
+endif

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -17,6 +17,13 @@ if cuda_dep.found()
     dependencies: [cuda_dep],
     install: true,
   )
+  executable(
+    'upcie_probe_vfio_bar_import_cuda',
+    files('upcie_probe_vfio_bar_import_cuda.c'),
+    include_directories: incdir,
+    dependencies: [cuda_dep],
+    install: true,
+  )
 endif
 
 cc = meson.get_compiler('c')
@@ -27,6 +34,14 @@ if hip_lib.found() and hip_hdr
   executable(
     'upcie_probe_dmabuf_hip',
     files('upcie_probe_dmabuf_hip.c'),
+    include_directories: incdir,
+    dependencies: [hip_lib],
+    c_args: ['-D__HIP_PLATFORM_AMD__'],
+    install: true,
+  )
+  executable(
+    'upcie_probe_vfio_bar_import_hip',
+    files('upcie_probe_vfio_bar_import_hip.c'),
     include_directories: incdir,
     dependencies: [hip_lib],
     c_args: ['-D__HIP_PLATFORM_AMD__'],

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -88,4 +88,12 @@ if hip_lib.found() and hip_hdr
     c_args: ['-D__HIP_PLATFORM_AMD__'],
     install: true,
   )
+  executable(
+    'upcie_probe_vfio_share_gpu_hip',
+    files('upcie_probe_vfio_share_gpu_hip.c'),
+    include_directories: incdir,
+    dependencies: [hip_lib],
+    c_args: ['-D__HIP_PLATFORM_AMD__'],
+    install: true,
+  )
 endif

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -4,6 +4,13 @@
 
 incdir = include_directories('../include', '.')
 
+executable(
+  'upcie_probe_vfio_delegate',
+  files('upcie_probe_vfio_delegate.c'),
+  include_directories: incdir,
+  install: true,
+)
+
 cuda_dep = dependency(
   'cuda', modules: ['cuda'],
   required: false,

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -11,6 +11,20 @@ executable(
   install: true,
 )
 
+executable(
+  'upcie_probe_vfio_cdev',
+  files('upcie_probe_vfio_cdev.c'),
+  include_directories: incdir,
+  install: true,
+)
+
+executable(
+  'upcie_probe_vfio_share',
+  files('upcie_probe_vfio_share.c'),
+  include_directories: incdir,
+  install: true,
+)
+
 cuda_dep = dependency(
   'cuda', modules: ['cuda'],
   required: false,

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -25,6 +25,14 @@ if cuda_dep.found()
     install: true,
   )
 
+  executable(
+    'upcie_probe_vram_ioas_cuda',
+    files('upcie_probe_vram_ioas_cuda.c'),
+    include_directories: incdir,
+    dependencies: [cuda_dep],
+    install: true,
+  )
+
   nvcc = find_program('nvcc')
 
   probe_vfio_share_gpu_kernel_obj = custom_target(
@@ -67,6 +75,14 @@ if hip_lib.found() and hip_hdr
   executable(
     'upcie_probe_vfio_bar_import_hip',
     files('upcie_probe_vfio_bar_import_hip.c'),
+    include_directories: incdir,
+    dependencies: [hip_lib],
+    c_args: ['-D__HIP_PLATFORM_AMD__'],
+    install: true,
+  )
+  executable(
+    'upcie_probe_vram_ioas_hip',
+    files('upcie_probe_vram_ioas_hip.c'),
     include_directories: incdir,
     dependencies: [hip_lib],
     c_args: ['-D__HIP_PLATFORM_AMD__'],

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -24,6 +24,31 @@ if cuda_dep.found()
     dependencies: [cuda_dep],
     install: true,
   )
+
+  nvcc = find_program('nvcc')
+
+  probe_vfio_share_gpu_kernel_obj = custom_target(
+    'probe_vfio_share_gpu_kernel_obj',
+    input: files('probe_vfio_share_gpu_kernel.cu'),
+    output: 'probe_vfio_share_gpu_kernel.o',
+    command: [
+      nvcc, '-c', '-arch=' + get_option('cuda-arch'),
+      '-I', meson.project_source_root() / 'include',
+      '-include', meson.project_build_root() / 'upcie_config.h',
+      '@INPUT@', '-o', '@OUTPUT@',
+    ],
+  )
+
+  executable(
+    'upcie_probe_vfio_share_gpu_cuda',
+    [files('upcie_probe_vfio_share_gpu_cuda.c'), probe_vfio_share_gpu_kernel_obj],
+    include_directories: incdir,
+    dependencies: [cuda_dep],
+    # nvcc emits a C++ static-init guard in the kernel object (CUDA 13), so
+    # link libstdc++ for __cxa_guard_acquire/release in this C target.
+    link_args: ['-lstdc++'],
+    install: true,
+  )
 endif
 
 cc = meson.get_compiler('c')

--- a/tools/probe_dmabuf.h
+++ b/tools/probe_dmabuf.h
@@ -39,6 +39,14 @@ static int
 probe_alloc(uint64_t *va, size_t nbytes);
 
 /**
+ * Supplied by the flavour: recover the allocation `va` falls inside
+ *
+ * @return 0 on success, the runtime's own error code otherwise.
+ */
+static int
+probe_addrrange(uint64_t *base, size_t *size, uint64_t va);
+
+/**
  * Collapse the scatter list into maximal physically contiguous runs.
  *
  * An exporter may split a run at its own page size even when the addresses are
@@ -170,6 +178,27 @@ probe_run(size_t size)
 	probe_one("2M at base + 2M", a + (2UL << 20), 2UL << 20);
 	probe_one("3M at base", a, 3UL << 20);
 	probe_one("whole allocation", a, size);
+
+	printf("\n  an odd-sized allocation\n");
+	{
+		const size_t odd = (3UL << 20) + 4096;
+		uint64_t c = 0, base = 0;
+		size_t rsize = 0;
+
+		if (probe_alloc(&c, odd)) {
+			printf("    allocation FAILED\n");
+		} else {
+			printf("    requested(%zu) base(0x%" PRIx64 ") base%%2M(%" PRIu64 ")\n",
+			       odd, c, c % (2UL << 20));
+			if (probe_addrrange(&base, &rsize, c)) {
+				printf("    range recovery FAILED\n");
+			} else {
+				printf("    recovered size(%zu) rounded_up_to_2M(%s)\n", rsize,
+				       rsize % (2UL << 20) ? "no" : "yes");
+			}
+			probe_one("whole odd allocation", c, rsize ? rsize : odd);
+		}
+	}
 
 	printf("\n  recovering the allocation from a pointer into it\n");
 	probe_report_addrrange("at base", a, a, size);

--- a/tools/probe_dmabuf.h
+++ b/tools/probe_dmabuf.h
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * dma-buf export probe: what does a vendor runtime actually give us?
+ * ==================================================================
+ *
+ * Flavour-agnostic body of upcie_probe_dmabuf_{cuda,hip}. A flavour defines the
+ * functions prototyped below, includes this header, and calls probe_run(). The
+ * prototypes are what state the contract: a flavour missing one, or defining it
+ * with another signature, is diagnosed here rather than at the point of use.
+ *
+ * The questions this answers, per flavour, are in tools/README.md.
+ *
+ * @file probe_dmabuf.h
+ */
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/**
+ * Supplied by the flavour: export `nbytes` from `va` as a dma-buf descriptor
+ *
+ * @return 0 on success, the runtime's own error code otherwise.
+ */
+static int
+probe_export(int *fd, uint64_t va, size_t nbytes);
+
+/**
+ * Supplied by the flavour: allocate `nbytes` of device memory
+ *
+ * @return 0 on success, the runtime's own error code otherwise.
+ */
+static int
+probe_alloc(uint64_t *va, size_t nbytes);
+
+/**
+ * Collapse the scatter list into maximal physically contiguous runs.
+ *
+ * An exporter may split a run at its own page size even when the addresses are
+ * adjacent, so the segment count overstates fragmentation. What a translator
+ * cares about is where the addresses actually jump.
+ *
+ * @param nruns_out  Number of maximal contiguous runs.
+ * @param granule_out Largest power-of-two granule the list may be indexed by:
+ *        the largest power of two dividing every run boundary, since a granule
+ *        window is safe exactly when no jump falls inside it. When there is a
+ *        single run this is the described length, meaning no jump anywhere.
+ */
+static void
+probe_runs(struct dmabuf *dmabuf, size_t *nruns_out, uint64_t *granule_out)
+{
+	uint64_t off = 0, divisor = 0;
+	size_t nruns = 1;
+
+	for (size_t j = 0; j < dmabuf->npages; ++j) {
+		if (j && (dmabuf->pages[j].addr !=
+			  dmabuf->pages[j - 1].addr + dmabuf->pages[j - 1].len)) {
+			divisor |= off;
+			nruns++;
+		}
+		off += dmabuf->pages[j].len;
+	}
+	divisor |= off;
+
+	*nruns_out = nruns;
+	/* Lowest set bit: the largest power of two dividing every boundary. */
+	*granule_out = divisor & (~divisor + 1);
+}
+
+/**
+ * Export [va, va + nbytes) and report what came back.
+ *
+ * `expect_nbytes` is what a caller would assume the export describes.
+ */
+static void
+probe_one(const char *what, uint64_t va, size_t nbytes)
+{
+	struct dmabuf attach = {0};
+	uint64_t total = 0, shortest = ~0ULL, granule = 0;
+	size_t nruns = 0;
+	int fd = -1;
+	int err;
+
+	printf("  %-26s va(0x%" PRIx64 ") nbytes(%zu)\n", what, va, nbytes);
+
+	err = probe_export(&fd, va, nbytes);
+	if (err) {
+		printf("      export FAILED, rc(%d)\n", err);
+		return;
+	}
+
+	err = dmabuf_import_attach(fd, &attach);
+	if (err) {
+		printf("      dmabuf_import_attach() FAILED, err(%d)\n", err);
+		close(fd);
+		return;
+	}
+
+	for (size_t j = 0; j < attach.npages; ++j) {
+		total += attach.pages[j].len;
+		if (attach.pages[j].len < shortest) {
+			shortest = attach.pages[j].len;
+		}
+	}
+
+	printf("      nsegments(%zu) described(%" PRIu64 ") %s requested(%zu)\n", attach.npages,
+	       total, total == nbytes ? "==" : "!=", nbytes);
+	probe_runs(&attach, &nruns, &granule);
+	printf("      first_addr(0x%" PRIx64 ") shortest_seg(%" PRIu64
+	       ") phys_runs(%zu) granule(%" PRIu64 ")\n",
+	       attach.pages[0].addr, shortest, nruns, granule);
+
+	dmabuf_import_detach(&attach);
+}
+
+/**
+ * Can the allocation a pointer falls in be recovered from the pointer?
+ *
+ * A per-allocation export is only usable if so: the exported scatter list is
+ * indexed from the base of the allocation, and a caller registering a
+ * sub-range has to be placed at the right offset within it.
+ */
+static void
+probe_report_addrrange(const char *what, uint64_t va, uint64_t expect_base, size_t expect_size)
+{
+	uint64_t base = 0;
+	size_t size = 0;
+	int err;
+
+	err = probe_addrrange(&base, &size, va);
+	if (err) {
+		printf("  %-26s va(0x%" PRIx64 ") -> FAILED rc(%d)\n", what, va, err);
+		return;
+	}
+
+	printf("  %-26s va(0x%" PRIx64 ") -> base(0x%" PRIx64 ") size(%zu) base %s size %s\n",
+	       what, va, base, size, base == expect_base ? "ok" : "WRONG",
+	       size == expect_size ? "ok" : "WRONG");
+}
+
+/**
+ * Probe two separate device allocations of `size` bytes each.
+ */
+static int
+probe_run(size_t size)
+{
+	uint64_t a = 0, b = 0;
+	int err;
+
+	err = probe_alloc(&a, size);
+	if (err) {
+		printf("probe_alloc() FAILED, rc(%d)\n", err);
+		return err;
+	}
+	err = probe_alloc(&b, size);
+	if (err) {
+		printf("probe_alloc() FAILED, rc(%d)\n", err);
+		return err;
+	}
+
+	printf("\nallocation A base(0x%" PRIx64 ") size(%zu)\n", a, size);
+	probe_one("4K at base", a, 4096);
+	probe_one("2M at base", a, 2UL << 20);
+	probe_one("4K at base + 4K", a + 4096, 4096);
+	probe_one("2M at base + 2M", a + (2UL << 20), 2UL << 20);
+	probe_one("3M at base", a, 3UL << 20);
+	probe_one("whole allocation", a, size);
+
+	printf("\n  recovering the allocation from a pointer into it\n");
+	probe_report_addrrange("at base", a, a, size);
+	probe_report_addrrange("at base + 3M + 4K", a + (3UL << 20) + 4096, a, size);
+	probe_report_addrrange("at last byte", a + size - 1, a, size);
+
+	printf("\nallocation B base(0x%" PRIx64 ") size(%zu)\n", b, size);
+	probe_one("4K at base", b, 4096);
+	probe_one("whole allocation", b, size);
+
+	return 0;
+}

--- a/tools/probe_vfio_bar_import.h
+++ b/tools/probe_vfio_bar_import.h
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * vfio BAR dma-buf import probe: will a GPU runtime map another device's MMIO?
+ * ===========================================================================
+ *
+ * VFIO_DEVICE_FEATURE_DMA_BUF exports a slice of a device's BAR as a dma-buf.
+ * The exporter does not implement CPU mmap, so a process holding only that
+ * descriptor cannot produce a host address, and cuMemHostRegister() with
+ * CU_MEMHOSTREGISTER_IOMEMORY, which is how the GPU-initiated NVMe path
+ * reaches a doorbell today, has nothing to register.
+ *
+ * The question this settles is whether the other route exists: does the GPU
+ * runtime import the descriptor itself and hand back a device pointer? If it
+ * does, MMIO can be delegated to a process that never holds the device fd. If
+ * it does not, delegating the doorbells means delegating the device.
+ *
+ * Reads rather than writes, and defaults to offset 0, so what it touches is
+ * CAP rather than a doorbell: the host reads the same register through its own
+ * mapping and the two are printed side by side. A device-side value equal to
+ * the host's is the whole result.
+ *
+ * The flavour supplies
+ * bar_import_probe_{rt_init,selftest,import,read,release,why}, then calls
+ * bar_import_probe_run(). The self-import is a control: a runtime that will not
+ * import a descriptor it exported itself is not telling us anything about
+ * vfio.
+ *
+ * @file probe_vfio_bar_import.h
+ */
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <upcie/upcie.h>
+
+struct bar_import_probe_args {
+	const char *cdev; ///< /dev/vfio/devices/vfioN
+	uint32_t region;  ///< BAR/region index
+	uint64_t offset;  ///< Offset within the region
+	uint64_t length;  ///< Length of the exported slice
+};
+
+static void
+bar_import_probe_say(const char *what, const char *how)
+{
+	printf("  %-34s %s\n", what, how);
+}
+
+static int
+bar_import_probe_run(const struct bar_import_probe_args *args)
+{
+	struct vfio_region_info region = {.index = args->region};
+	struct iommufd iommufd = {0};
+	struct vfio_cdev dev = {0};
+	uint64_t devptr = 0;
+	uint32_t host_lo = 0, host_hi = 0, dev_lo = 0, dev_hi = 0;
+	uint32_t pair[2] = {0};
+	void *host_bar = NULL;
+	int dbuf_fd = -1;
+	int err;
+
+	printf("vfio_bar_import_probe: %s region=%u offset=0x%" PRIx64 " length=0x%" PRIx64 "\n",
+	       args->cdev, args->region, args->offset, args->length);
+
+	err = iommufd_open(&iommufd);
+	if (err) {
+		bar_import_probe_say("iommufd_open()", strerror(-err));
+		return err;
+	}
+
+	err = iommufd_ioas_alloc(&iommufd);
+	if (err) {
+		bar_import_probe_say("iommufd_ioas_alloc()", strerror(-err));
+		goto out_iommufd;
+	}
+
+	err = vfio_cdev_open(args->cdev, &dev);
+	if (err) {
+		bar_import_probe_say("vfio_cdev_open()", strerror(-err));
+		goto out_ioas;
+	}
+
+	err = iommufd_bind(&iommufd, &dev);
+	if (err) {
+		bar_import_probe_say("iommufd_bind()", strerror(-err));
+		goto out_dev;
+	}
+
+	err = iommufd_attach(&iommufd, &dev);
+	if (err) {
+		bar_import_probe_say("iommufd_attach()", strerror(-err));
+		goto out_dev;
+	}
+	bar_import_probe_say("bind and attach", "ok");
+
+	if (vfio_device_get_region_info(dev.fd, &region)) {
+		bar_import_probe_say("GET_REGION_INFO", strerror(errno));
+		err = -errno;
+		goto out_detach;
+	}
+	printf("  %-34s size=0x%llx mmap=%s\n", "region", (unsigned long long)region.size,
+	       (region.flags & VFIO_REGION_INFO_FLAG_MMAP) ? "yes" : "no");
+
+	host_bar = vfio_map_region(dev.fd, region.size, region.offset);
+	if (host_bar == MAP_FAILED) {
+		host_bar = NULL;
+		bar_import_probe_say("host mmap(region)", strerror(errno));
+	} else {
+		host_lo = mmio_read32(host_bar, args->offset);
+		host_hi = mmio_read32(host_bar, args->offset + 4);
+		printf("  %-34s 0x%08" PRIx32 " 0x%08" PRIx32 "\n", "host read", host_lo, host_hi);
+	}
+
+	dbuf_fd = vfio_device_bar_export_dmabuf(dev.fd, args->region, args->offset, args->length);
+	if (dbuf_fd < 0) {
+		bar_import_probe_say("EXPORT_DMA_BUF", strerror(-dbuf_fd));
+		err = dbuf_fd;
+		goto out_unmap;
+	}
+	bar_import_probe_say("EXPORT_DMA_BUF", "ok");
+
+	err = bar_import_probe_rt_init();
+	if (err) {
+		bar_import_probe_say("GPU runtime init", "FAILED");
+		goto out_dmabuf;
+	}
+
+	{
+		char why[128] = {0};
+
+		err = bar_import_probe_selftest(why, sizeof(why));
+		bar_import_probe_say(err ? "self-import (control)" : "self-import (control) ok",
+				     why);
+	}
+
+	/* The runtime takes ownership of the descriptor on import, so it is not
+	 * closed here even on the failure paths below. */
+	err = bar_import_probe_import(dbuf_fd, args->length, &devptr);
+	if (err) {
+		printf("  %-34s FAILED (%s)\n", "import into GPU runtime", bar_import_probe_why());
+		printf("\nVerdict: MMIO cannot be delegated by descriptor to this runtime.\n");
+		goto out_release;
+	}
+	printf("  %-34s ok, devptr=0x%" PRIx64 "\n", "import into GPU runtime", devptr);
+
+	err = bar_import_probe_read(devptr, sizeof(pair), pair);
+	if (err) {
+		printf("  %-34s FAILED rc(%d)\n", "device-side read", err);
+		printf("\nVerdict: imported, but the mapping is not readable from the device.\n");
+		goto out_release;
+	}
+	dev_lo = pair[0];
+	dev_hi = pair[1];
+	printf("  %-34s 0x%08" PRIx32 " 0x%08" PRIx32 "\n", "device-side read", dev_lo, dev_hi);
+
+	if (host_bar && dev_lo == host_lo && dev_hi == host_hi) {
+		printf("\nVerdict: the device reads what the host reads; MMIO can be "
+		       "delegated by descriptor.\n");
+	} else if (host_bar) {
+		printf("\nVerdict: the mapping resolved but does not read as the host's; "
+		       "not usable as it stands.\n");
+	} else {
+		printf("\nVerdict: imported and read, with no host mapping to compare "
+		       "against.\n");
+	}
+
+out_release:
+	bar_import_probe_release();
+	goto out_unmap;
+
+out_dmabuf:
+	close(dbuf_fd);
+out_unmap:
+	if (host_bar) {
+		munmap(host_bar, region.size);
+	}
+out_detach:
+	iommufd_detach(&dev);
+out_dev:
+	vfio_cdev_close(&dev);
+out_ioas:
+	iommufd_destroy(&iommufd, iommufd.ioas_id);
+out_iommufd:
+	iommufd_close(&iommufd);
+
+	return err;
+}
+
+static int
+bar_import_probe_main(int argc, char *argv[])
+{
+	struct bar_import_probe_args args = {.region = 0, .offset = 0, .length = 0x1000};
+
+	if (argc < 2 || argc > 5) {
+		fprintf(stderr, "usage: %s <cdev> [region] [offset] [length]\n", argv[0]);
+		return 2;
+	}
+
+	args.cdev = argv[1];
+	if (argc > 2) {
+		args.region = (uint32_t)strtoul(argv[2], NULL, 0);
+	}
+	if (argc > 3) {
+		args.offset = (uint64_t)strtoull(argv[3], NULL, 0);
+	}
+	if (argc > 4) {
+		args.length = (uint64_t)strtoull(argv[4], NULL, 0);
+	}
+
+	bar_import_probe_run(&args);
+
+	return EXIT_SUCCESS;
+}

--- a/tools/probe_vfio_share_gpu.h
+++ b/tools/probe_vfio_share_gpu.h
@@ -1,0 +1,408 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * Delegated MMIO probe: can a secondary reach the BAR from a GPU kernel?
+ * =====================================================================
+ *
+ * A process can pass a vfio device fd to an unrelated process over SCM_RIGHTS,
+ * and the receiver can map BAR0 and read a register. What that leaves untested
+ * is the step the GPU-initiated NVMe path depends on: registering a window of
+ * that received mapping as I/O memory with cuMemHostRegister(), and reaching
+ * it from an SM.
+ *
+ * Two processes rather than a fork with a setuid in it. Dropping privilege is
+ * not the same state as never having had it: the dropped process keeps the
+ * supplementary groups it was started with unless they are cleared, and a uid
+ * change clears the dumpable flag, either of which could be what a refusal is
+ * really about. So the secondary is started separately, as whatever user it is
+ * started as, and the two meet over a named socket.
+ *
+ * It reads CAP rather than writing a doorbell, so nothing here disturbs a
+ * controller, and both sides print what they read.
+ *
+ * The flavour supplies share_probe_{rt_init,register,read,why} and the two
+ * name macros, then includes this and calls share_probe_main().
+ *
+ * Usage:
+ *   upcie_probe_vfio_share_gpu_cuda primary <cdev> <socket>
+ *   upcie_probe_vfio_share_gpu_cuda secondary <socket>
+ *   upcie_probe_vfio_share_gpu_cuda standalone <cdev>
+ *
+ * The standalone mode is the control: no delegation, the process opens the
+ * device itself. Run as an ordinary user it says whether a refusal is about
+ * the caller or about the descriptor having been passed.
+ *
+ * The primary serves one secondary and exits when it disconnects, so run it in
+ * the background and start the secondary as the user in question, for example
+ * with setpriv --reuid=1000 --regid=1000 --clear-groups.
+ *
+ * @file upcie_probe_vfio_share_gpu_cuda.c
+ */
+
+/* upcie.h sets the feature-test macros, so it comes before anything that
+ * pulls in features.h. */
+static void
+say(const char *who, const char *what, const char *how)
+{
+	printf("  [%s] %-28s %s\n", who, what, how);
+}
+
+static int
+send_fd(int sock, int fd)
+{
+	char control[CMSG_SPACE(sizeof(int))] = {0};
+	struct iovec iov = {.iov_base = (void *)"f", .iov_len = 1};
+	struct msghdr msg = {0};
+	struct cmsghdr *cmsg;
+
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+	msg.msg_control = control;
+	msg.msg_controllen = sizeof(control);
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_RIGHTS;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+	memcpy(CMSG_DATA(cmsg), &fd, sizeof(int));
+
+	return sendmsg(sock, &msg, 0) < 0 ? -errno : 0;
+}
+
+static int
+recv_fd(int sock, int *fd)
+{
+	char control[CMSG_SPACE(sizeof(int))] = {0};
+	char byte = 0;
+	struct iovec iov = {.iov_base = &byte, .iov_len = 1};
+	struct msghdr msg = {0};
+	struct cmsghdr *cmsg;
+
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+	msg.msg_control = control;
+	msg.msg_controllen = sizeof(control);
+
+	if (recvmsg(sock, &msg, 0) < 0) {
+		return -errno;
+	}
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	if (!cmsg || cmsg->cmsg_type != SCM_RIGHTS) {
+		return -EPROTO;
+	}
+	memcpy(fd, CMSG_DATA(cmsg), sizeof(int));
+
+	return 0;
+}
+
+/**
+ * What a process does with a device fd, however it came by one.
+ */
+static int
+use_bar(const char *who, int fd, uint64_t offset)
+{
+	struct vfio_region_info region = {.index = 0};
+	uint32_t gpu[2] = {0};
+	void *bar0;
+	int err;
+
+	if (vfio_device_get_region_info(fd, &region)) {
+		say(who, "GET_REGION_INFO(BAR0)", strerror(errno));
+		return -errno;
+	}
+
+	bar0 = vfio_map_region(fd, region.size, region.offset);
+	if (bar0 == MAP_FAILED) {
+		say(who, "mmap(BAR0)", strerror(errno));
+		return -errno;
+	}
+	printf("  [%s] %-28s 0x%08" PRIx32 " 0x%08" PRIx32 "\n", who, "host read",
+	       mmio_read32(bar0, offset), mmio_read32(bar0, offset + 4));
+
+	if (share_probe_rt_init()) {
+		say(who, "GPU runtime init", "FAILED");
+		return -EIO;
+	}
+
+	/* The step this probe exists for: the shipping GPU-initiated path
+	 * registers a doorbell the same way. */
+	err = share_probe_register((uint8_t *)bar0 + offset, 2 * sizeof(uint32_t));
+	if (err) {
+		say(who, SHARE_PROBE_REGISTER_NAME, share_probe_why());
+		return -EIO;
+	}
+	say(who, SHARE_PROBE_REGISTER_NAME, "ok");
+
+	err = share_probe_read((uint8_t *)bar0 + offset, gpu);
+	if (err) {
+		say(who, SHARE_PROBE_READ_NAME, "FAILED");
+		return -EIO;
+	}
+	printf("  [%s] %-28s 0x%08" PRIx32 " 0x%08" PRIx32 "\n", who, SHARE_PROBE_READ_NAME,
+	       gpu[0], gpu[1]);
+
+	return 0;
+}
+
+static void
+say_creds(const char *who)
+{
+	char note[96];
+
+	snprintf(note, sizeof(note), "uid=%u euid=%u gid=%u", (unsigned)getuid(),
+		 (unsigned)geteuid(), (unsigned)getgid());
+	say(who, "running as", note);
+}
+
+/**
+ * The secondary: a received descriptor and nothing else.
+ */
+static int
+secondary(int sock, uint64_t offset)
+{
+	int fd = -1;
+	int err;
+
+	say_creds("secondary");
+
+	err = recv_fd(sock, &fd);
+	if (err) {
+		say("secondary", "recv device fd", strerror(-err));
+		return err;
+	}
+	say("secondary", "recv device fd", "ok");
+
+	return use_bar("secondary", fd, offset);
+}
+
+/**
+ * Standalone: no delegation at all, the process opens the device itself.
+ *
+ * This is the control for the secondary's result. If it is refused the same
+ * way, the refusal is about the calling process rather than about the
+ * descriptor having been passed to it. Needs the cdev and /dev/iommu to be
+ * reachable by whoever runs it.
+ */
+static int
+standalone(const char *cdev, uint64_t offset)
+{
+	struct iommufd iommufd = {0};
+	struct vfio_cdev dev = {0};
+	int err;
+
+	say_creds("standalone");
+
+	err = iommufd_open(&iommufd);
+	if (err) {
+		say("standalone", "iommufd_open()", strerror(-err));
+		return err;
+	}
+
+	err = iommufd_ioas_alloc(&iommufd);
+	if (err) {
+		say("standalone", "iommufd_ioas_alloc()", strerror(-err));
+		return err;
+	}
+
+	err = vfio_cdev_open(cdev, &dev);
+	if (err) {
+		say("standalone", "vfio_cdev_open()", strerror(-err));
+		return err;
+	}
+
+	err = iommufd_bind(&iommufd, &dev);
+	if (err) {
+		say("standalone", "iommufd_bind()", strerror(-err));
+		return err;
+	}
+
+	err = iommufd_attach(&iommufd, &dev);
+	if (err) {
+		say("standalone", "iommufd_attach()", strerror(-err));
+		return err;
+	}
+	say("standalone", "bind and attach", "ok");
+
+	return use_bar("standalone", dev.fd, offset);
+}
+
+static int
+listen_at(const char *path)
+{
+	struct sockaddr_un addr = {.sun_family = AF_UNIX};
+	int sock;
+
+	unlink(path);
+
+	sock = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (sock < 0) {
+		return -errno;
+	}
+
+	snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", path);
+
+	if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) || listen(sock, 1)) {
+		close(sock);
+		return -errno;
+	}
+
+	/* The secondary is another user; the socket has to be reachable by it. */
+	if (chmod(path, 0666)) {
+		close(sock);
+		return -errno;
+	}
+
+	return sock;
+}
+
+static int
+connect_to(const char *path)
+{
+	struct sockaddr_un addr = {.sun_family = AF_UNIX};
+	int sock;
+
+	sock = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (sock < 0) {
+		return -errno;
+	}
+
+	snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", path);
+
+	if (connect(sock, (struct sockaddr *)&addr, sizeof(addr))) {
+		close(sock);
+		return -errno;
+	}
+
+	return sock;
+}
+
+/**
+ * The primary: holds the device, hands over the descriptor, serves one
+ * secondary and leaves when it disconnects.
+ */
+static int
+primary(const char *cdev, const char *path, uint64_t offset)
+{
+	struct vfio_region_info region = {.index = 0};
+	struct iommufd iommufd = {0};
+	struct vfio_cdev dev = {0};
+	char byte;
+	void *bar0;
+	int listener = -1, sock = -1;
+	int err;
+
+	err = iommufd_open(&iommufd);
+	if (err) {
+		say("primary", "iommufd_open()", strerror(-err));
+		return err;
+	}
+
+	err = iommufd_ioas_alloc(&iommufd);
+	if (err) {
+		say("primary", "iommufd_ioas_alloc()", strerror(-err));
+		return err;
+	}
+
+	err = vfio_cdev_open(cdev, &dev);
+	if (err) {
+		say("primary", "vfio_cdev_open()", strerror(-err));
+		return err;
+	}
+
+	err = iommufd_bind(&iommufd, &dev);
+	if (err) {
+		say("primary", "iommufd_bind()", strerror(-err));
+		return err;
+	}
+
+	err = iommufd_attach(&iommufd, &dev);
+	if (err) {
+		say("primary", "iommufd_attach()", strerror(-err));
+		return err;
+	}
+	say("primary", "bind and attach", "ok");
+
+	if (vfio_device_get_region_info(dev.fd, &region)) {
+		say("primary", "GET_REGION_INFO(BAR0)", strerror(errno));
+		return -errno;
+	}
+
+	bar0 = vfio_map_region(dev.fd, region.size, region.offset);
+	if (bar0 == MAP_FAILED) {
+		say("primary", "mmap(BAR0)", strerror(errno));
+		return -errno;
+	}
+	printf("  [primary]   %-28s 0x%08" PRIx32 " 0x%08" PRIx32 "\n", "host read",
+	       mmio_read32(bar0, offset), mmio_read32(bar0, offset + 4));
+
+	listener = listen_at(path);
+	if (listener < 0) {
+		say("primary", "listen()", strerror(-listener));
+		return listener;
+	}
+	say("primary", "listening", path);
+
+	sock = accept(listener, NULL, NULL);
+	if (sock < 0) {
+		say("primary", "accept()", strerror(errno));
+		close(listener);
+		return -errno;
+	}
+
+	err = send_fd(sock, dev.fd);
+	if (err) {
+		say("primary", "send device fd", strerror(-err));
+		close(sock);
+		close(listener);
+		return err;
+	}
+	say("primary", "send device fd", "ok");
+
+	/* Hold everything open until the secondary is done with it. */
+	while (read(sock, &byte, 1) > 0) {
+	}
+	say("primary", "secondary disconnected", "ok");
+
+	close(sock);
+	close(listener);
+	unlink(path);
+
+	return 0;
+}
+
+static int
+share_probe_main(int argc, char *argv[])
+{
+	const uint64_t offset = 0;
+	int err;
+
+	setvbuf(stdout, NULL, _IOLBF, 0);
+
+	if (argc == 4 && !strcmp(argv[1], "primary")) {
+		printf("vfio_share_gpu_probe primary: %s\n", argv[2]);
+		err = primary(argv[2], argv[3], offset);
+	} else if (argc == 3 && !strcmp(argv[1], "standalone")) {
+		printf("vfio_share_gpu_probe standalone: %s\n", argv[2]);
+		err = standalone(argv[2], offset);
+	} else if (argc == 3 && !strcmp(argv[1], "secondary")) {
+		int sock = connect_to(argv[2]);
+
+		printf("vfio_share_gpu_probe secondary: %s\n", argv[2]);
+		if (sock < 0) {
+			say("secondary", "connect()", strerror(-sock));
+			return EXIT_FAILURE;
+		}
+
+		err = secondary(sock, offset);
+		close(sock);
+	} else {
+		fprintf(stderr, "usage: %s primary <cdev> <socket>\n", argv[0]);
+		fprintf(stderr, "       %s secondary <socket>\n", argv[0]);
+		fprintf(stderr, "       %s standalone <cdev>\n", argv[0]);
+		return 2;
+	}
+
+	return err ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tools/probe_vfio_share_gpu_kernel.cu
+++ b/tools/probe_vfio_share_gpu_kernel.cu
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * Read two dwords of MMIO from an SM, for upcie_probe_vfio_share_gpu_cuda.
+ *
+ * The copy engine is not what rings a doorbell, so the read that answers the
+ * question has to come from a kernel rather than from cuMemcpyDtoH().
+ */
+
+#include <cuda_runtime.h>
+#include <stdint.h>
+
+__global__ static void
+upcie_probe_read_mmio_kernel(const volatile uint32_t *src, uint32_t *dst)
+{
+	dst[0] = src[0];
+	dst[1] = src[1];
+}
+
+extern "C" int
+upcie_probe_read_mmio(const void *mmio, uint32_t *out)
+{
+	uint32_t *dst = NULL;
+	cudaError_t cerr;
+
+	cerr = cudaMalloc((void **)&dst, 2 * sizeof(uint32_t));
+	if (cerr != cudaSuccess) {
+		return (int)cerr;
+	}
+
+	upcie_probe_read_mmio_kernel<<<1, 1>>>((const volatile uint32_t *)mmio, dst);
+
+	cerr = cudaDeviceSynchronize();
+	if (cerr != cudaSuccess) {
+		cudaFree(dst);
+		return (int)cerr;
+	}
+
+	cerr = cudaMemcpy(out, dst, 2 * sizeof(uint32_t), cudaMemcpyDeviceToHost);
+	cudaFree(dst);
+
+	return cerr == cudaSuccess ? 0 : (int)cerr;
+}

--- a/tools/probe_vram_ioas.h
+++ b/tools/probe_vram_ioas.h
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * VRAM into an IOAS: will the kernel map GPU memory for a peer to DMA against?
+ * ===========================================================================
+ *
+ * Under uio_pci_generic a controller consumes physical addresses, and a GPU
+ * allocation reaches it through the dma-buf scatter list. Under vfio-pci it
+ * consumes IOVAs, so the same allocation has to enter the IOAS, which means
+ * IOMMU_IOAS_MAP_FILE has to accept a dma-buf exported by the GPU runtime.
+ *
+ * iommufd.h records that as of 6.19 it does not, accepting only dma-bufs
+ * exported by vfio-pci. That is a comment about a kernel we no longer run, and
+ * the answer decides whether a controller under an IOMMU can DMA into VRAM at
+ * all, which is upstream of every question about sharing one between
+ * processes. So it is asked rather than assumed.
+ *
+ * A memfd is mapped first as a control, since a MAP_FILE that refuses
+ * everything would say nothing about GPU memory in particular.
+ *
+ * The flavour supplies vram_ioas_probe_{rt_init,alloc_export}, then calls
+ * vram_ioas_probe_run().
+ *
+ * @file probe_vram_ioas.h
+ */
+
+#include <upcie/upcie.h>
+
+static void
+vram_ioas_probe_say(const char *what, const char *how)
+{
+	printf("  %-34s %s\n", what, how);
+}
+
+static int
+vram_ioas_probe_run(size_t nbytes)
+{
+	struct iommufd iommufd = {0};
+	uint64_t iova = 0;
+	int dmabuf_fd = -1;
+	int memfd = -1;
+	int err;
+
+	printf("vram_ioas_probe: %zu bytes\n", nbytes);
+
+	err = iommufd_open(&iommufd);
+	if (err) {
+		vram_ioas_probe_say("iommufd_open()", strerror(-err));
+		return err;
+	}
+
+	err = iommufd_ioas_alloc(&iommufd);
+	if (err) {
+		vram_ioas_probe_say("iommufd_ioas_alloc()", strerror(-err));
+		goto out;
+	}
+	vram_ioas_probe_say("iommufd_ioas_alloc()", "ok");
+
+	memfd = memfd_create("vram_ioas_probe", 0);
+	if (memfd < 0 || ftruncate(memfd, (off_t)nbytes)) {
+		vram_ioas_probe_say("memfd_create()", strerror(errno));
+		err = -errno;
+		goto out;
+	}
+
+	err = iommufd_ioas_map_file(&iommufd, memfd, 0, nbytes,
+				    IOMMU_IOAS_MAP_READABLE | IOMMU_IOAS_MAP_WRITEABLE, &iova);
+	if (err) {
+		printf("  %-34s %s\n", "MAP_FILE(memfd) [control]", strerror(-err));
+	} else {
+		printf("  %-34s ok, iova=0x%" PRIx64 "\n", "MAP_FILE(memfd) [control]", iova);
+	}
+
+	err = vram_ioas_probe_rt_init();
+	if (err) {
+		vram_ioas_probe_say("GPU runtime init", "FAILED");
+		goto out;
+	}
+
+	err = vram_ioas_probe_alloc_export(nbytes, &dmabuf_fd);
+	if (err) {
+		printf("  %-34s FAILED rc(%d)\n", "alloc and export as dma-buf", err);
+		goto out;
+	}
+	vram_ioas_probe_say("alloc and export as dma-buf", "ok");
+
+	iova = 0;
+	err = iommufd_ioas_map_file(&iommufd, dmabuf_fd, 0, nbytes,
+				    IOMMU_IOAS_MAP_READABLE | IOMMU_IOAS_MAP_WRITEABLE, &iova);
+	if (err) {
+		printf("  %-34s %s\n", "MAP_FILE(GPU dma-buf)", strerror(-err));
+		printf("\nVerdict: a controller behind an IOMMU cannot DMA into this "
+		       "memory.\n");
+	} else {
+		printf("  %-34s ok, iova=0x%" PRIx64 "\n", "MAP_FILE(GPU dma-buf)", iova);
+		printf("\nVerdict: GPU memory enters the IOAS; peer DMA into VRAM is "
+		       "available under vfio.\n");
+	}
+
+out:
+	if (dmabuf_fd >= 0) {
+		close(dmabuf_fd);
+	}
+	if (memfd >= 0) {
+		close(memfd);
+	}
+	iommufd_close(&iommufd);
+
+	return 0;
+}

--- a/tools/upcie_probe_dmabuf_cuda.c
+++ b/tools/upcie_probe_dmabuf_cuda.c
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * dma-buf export probe, CUDA flavour
+ *
+ * See tools/README.md.
+ */
+
+#include <upcie/upcie_cuda.h>
+
+static int
+probe_export(int *fd, uint64_t va, size_t nbytes)
+{
+	CUresult cr = cuMemGetHandleForAddressRange(fd, (CUdeviceptr)va, nbytes,
+						    CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
+
+	return cr == CUDA_SUCCESS ? 0 : (int)cr;
+}
+
+static int
+probe_alloc(uint64_t *va, size_t nbytes)
+{
+	CUdeviceptr ptr = 0;
+	CUresult cr = cuMemAlloc(&ptr, nbytes);
+
+	*va = (uint64_t)ptr;
+
+	return cr == CUDA_SUCCESS ? 0 : (int)cr;
+}
+
+static int
+probe_addrrange(uint64_t *base, size_t *size, uint64_t va)
+{
+	CUdeviceptr b = 0;
+	CUresult cr = cuMemGetAddressRange(&b, size, (CUdeviceptr)va);
+
+	*base = (uint64_t)b;
+
+	return cr == CUDA_SUCCESS ? 0 : (int)cr;
+}
+
+#include "probe_dmabuf.h"
+
+int
+main(void)
+{
+	struct cudamem_config config = {0};
+	CUcontext ctx;
+	CUdevice dev;
+	int version = 0;
+
+	/* cuCtxCreate has changed arity across CUDA releases; the primary
+	 * context is stable and is what the runtime API uses anyway. */
+	if (cuInit(0) || cuDriverGetVersion(&version) || cuDeviceGet(&dev, 0) ||
+	    cuDevicePrimaryCtxRetain(&ctx, dev) || cuCtxSetCurrent(ctx)) {
+		printf("CUDA initialization FAILED\n");
+		return EXIT_FAILURE;
+	}
+
+	if (cudamem_config_init(&config, 0)) {
+		printf("cudamem_config_init() FAILED\n");
+		return EXIT_FAILURE;
+	}
+
+	printf("cuda:\n");
+	printf("  driver_version: %d\n", version);
+	printf("  pagesize: %d\n", config.pagesize);
+	printf("  device_pagesize: %d\n", config.device_pagesize);
+	printf("  alloc_granularity: %zu\n", config.alloc_granularity);
+
+	return probe_run(64UL << 20) ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tools/upcie_probe_dmabuf_hip.c
+++ b/tools/upcie_probe_dmabuf_hip.c
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * dma-buf export probe, HIP flavour
+ *
+ * See tools/README.md.
+ */
+
+#include <upcie/upcie_hip.h>
+
+static int
+probe_export(int *fd, uint64_t va, size_t nbytes)
+{
+	hipError_t cr = hipMemGetHandleForAddressRange(fd, (hipDeviceptr_t)va, nbytes,
+						       hipMemRangeHandleTypeDmaBufFd, 0);
+
+	return cr == hipSuccess ? 0 : (int)cr;
+}
+
+static int
+probe_alloc(uint64_t *va, size_t nbytes)
+{
+	void *ptr = NULL;
+	hipError_t cr = hipMalloc(&ptr, nbytes);
+
+	*va = (uint64_t)ptr;
+
+	return cr == hipSuccess ? 0 : (int)cr;
+}
+
+static int
+probe_addrrange(uint64_t *base, size_t *size, uint64_t va)
+{
+	void *b = NULL;
+	hipError_t cr = hipMemGetAddressRange((hipDeviceptr_t *)&b, size, (hipDeviceptr_t)va);
+
+	*base = (uint64_t)b;
+
+	return cr == hipSuccess ? 0 : (int)cr;
+}
+
+#include "probe_dmabuf.h"
+
+int
+main(void)
+{
+	struct hipmem_config config = {0};
+	int version = 0;
+
+	if (hipInit(0) || hipSetDevice(0) || hipDriverGetVersion(&version)) {
+		printf("HIP initialization FAILED\n");
+		return EXIT_FAILURE;
+	}
+
+	if (hipmem_config_init(&config, 0)) {
+		printf("hipmem_config_init() FAILED\n");
+		return EXIT_FAILURE;
+	}
+
+	printf("hip:\n");
+	printf("  driver_version: %d\n", version);
+	printf("  pagesize: %d\n", config.pagesize);
+	printf("  device_pagesize: %d\n", config.device_pagesize);
+	printf("  alloc_granularity: %zu\n", config.alloc_granularity);
+
+	return probe_run(64UL << 20) ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tools/upcie_probe_vfio_bar_import_cuda.c
+++ b/tools/upcie_probe_vfio_bar_import_cuda.c
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * vfio BAR dma-buf import probe, CUDA flavour
+ *
+ * See tools/README.md.
+ */
+
+#include <upcie/upcie_cuda.h>
+
+static CUexternalMemory g_extmem;
+static CUdeviceptr g_devptr;
+static CUcontext g_ctx;
+
+static int
+bar_import_probe_rt_init(void)
+{
+	CUdevice dev;
+
+	if (cuInit(0) || cuDeviceGet(&dev, 0) || cuDevicePrimaryCtxRetain(&g_ctx, dev) ||
+	    cuCtxSetCurrent(g_ctx)) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static char g_why[256];
+
+static const char *
+bar_import_probe_why(void)
+{
+	return g_why;
+}
+
+static void
+bar_import_probe_note(const char *call, CUresult cr)
+{
+	const char *name = NULL;
+
+	cuGetErrorName(cr, &name);
+	snprintf(g_why + strlen(g_why), sizeof(g_why) - strlen(g_why), "%s%s=%s(%d)",
+		 g_why[0] ? ", " : "", call, name ? name : "?", (int)cr);
+}
+
+static int
+bar_import_probe_import(int dmabuf_fd, size_t nbytes, uint64_t *devptr)
+{
+	CUDA_EXTERNAL_MEMORY_HANDLE_DESC handle = {0};
+	CUDA_EXTERNAL_MEMORY_BUFFER_DESC buffer = {0};
+	CUmemGenericAllocationHandle mem;
+	CUresult cr;
+
+	handle.handle.fd = dmabuf_fd;
+	handle.size = nbytes;
+
+/* CU_EXTERNAL_MEMORY_HANDLE_TYPE_DMABUF_FD is an enumerator rather than a
+ * macro, so the guard has to be on the release that introduced it. */
+#if CUDA_VERSION >= 11070
+	/* The handle type that names what this descriptor is. OPAQUE_FD is
+	 * tried after it because it is what a reader of the older
+	 * documentation reaches for, and the two fail differently. */
+	handle.type = CU_EXTERNAL_MEMORY_HANDLE_TYPE_DMABUF_FD;
+
+	cr = cuImportExternalMemory(&g_extmem, &handle);
+	if (cr == CUDA_SUCCESS) {
+		goto mapped;
+	}
+	bar_import_probe_note("import(DMABUF_FD)", cr);
+#endif
+
+	handle.type = CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD;
+
+	cr = cuImportExternalMemory(&g_extmem, &handle);
+	if (cr != CUDA_SUCCESS) {
+		bar_import_probe_note("import(OPAQUE_FD)", cr);
+
+		/* The other way in: the VMM allocator's shareable handle. It
+		 * expects one of its own exports rather than an arbitrary
+		 * dma-buf, so this is asked as a question, not as a fallback
+		 * that is expected to work. */
+		cr = cuMemImportFromShareableHandle(&mem, (void *)(uintptr_t)dmabuf_fd,
+						    CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
+		bar_import_probe_note("cuMemImportFromShareableHandle", cr);
+
+		return (int)cr ? (int)cr : -EIO;
+	}
+
+#if CUDA_VERSION >= 11070
+mapped:
+#endif
+
+	buffer.offset = 0;
+	buffer.size = nbytes;
+
+	cr = cuExternalMemoryGetMappedBuffer(&g_devptr, g_extmem, &buffer);
+	if (cr != CUDA_SUCCESS) {
+		bar_import_probe_note("cuExternalMemoryGetMappedBuffer", cr);
+		return (int)cr;
+	}
+
+	*devptr = (uint64_t)g_devptr;
+
+	return 0;
+}
+
+static int
+bar_import_probe_read(uint64_t devptr, size_t nbytes, void *dst)
+{
+	CUresult cr = cuMemcpyDtoH(dst, (CUdeviceptr)devptr, nbytes);
+
+	return cr == CUDA_SUCCESS ? 0 : (int)cr;
+}
+
+static void
+bar_import_probe_release(void)
+{
+	if (g_extmem) {
+		cuDestroyExternalMemory(g_extmem);
+		g_extmem = NULL;
+	}
+}
+
+/**
+ * Does this runtime import a dma-buf it exported itself?
+ *
+ * Separates "will not import this descriptor" from "does not import
+ * descriptors", which is the difference between a limitation of the vfio
+ * exporter and one of the GPU stack.
+ */
+static int
+bar_import_probe_selftest(char *why, size_t why_nbytes)
+{
+#if CUDA_VERSION >= 11070
+	CUDA_EXTERNAL_MEMORY_HANDLE_DESC handle = {0};
+	CUexternalMemory extmem = NULL;
+	const char *name = NULL;
+	CUdeviceptr ptr = 0;
+	size_t nbytes = 2 << 20;
+	CUresult cr;
+	int fd = -1;
+
+	cr = cuMemAlloc(&ptr, nbytes);
+	if (cr != CUDA_SUCCESS) {
+		snprintf(why, why_nbytes, "cuMemAlloc failed");
+		return -EIO;
+	}
+
+	cr = cuMemGetHandleForAddressRange(&fd, ptr, nbytes, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+					   0);
+	if (cr != CUDA_SUCCESS) {
+		cuGetErrorName(cr, &name);
+		snprintf(why, why_nbytes, "export=%s(%d)", name ? name : "?", (int)cr);
+		cuMemFree(ptr);
+		return -EIO;
+	}
+
+	handle.type = CU_EXTERNAL_MEMORY_HANDLE_TYPE_DMABUF_FD;
+	handle.handle.fd = fd;
+	handle.size = nbytes;
+
+	cr = cuImportExternalMemory(&extmem, &handle);
+	cuGetErrorName(cr, &name);
+	snprintf(why, why_nbytes, "own dma-buf import=%s(%d)", name ? name : "?", (int)cr);
+
+	if (cr == CUDA_SUCCESS) {
+		cuDestroyExternalMemory(extmem);
+	}
+	cuMemFree(ptr);
+
+	return cr == CUDA_SUCCESS ? 0 : -EIO;
+#else
+	snprintf(why, why_nbytes, "runtime predates the dma-buf handle type");
+	return -ENOTSUP;
+#endif
+}
+
+#include "probe_vfio_bar_import.h"
+
+int
+main(int argc, char *argv[])
+{
+	return bar_import_probe_main(argc, argv);
+}

--- a/tools/upcie_probe_vfio_bar_import_hip.c
+++ b/tools/upcie_probe_vfio_bar_import_hip.c
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * vfio BAR dma-buf import probe, HIP flavour
+ *
+ * See tools/README.md.
+ */
+
+#include <upcie/upcie_hip.h>
+
+static hipExternalMemory_t g_extmem;
+static void *g_devptr;
+
+static int
+bar_import_probe_rt_init(void)
+{
+	if (hipInit(0) || hipSetDevice(0)) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static char g_why[256];
+
+static const char *
+bar_import_probe_why(void)
+{
+	return g_why;
+}
+
+static void
+bar_import_probe_note(const char *call, hipError_t herr)
+{
+	snprintf(g_why + strlen(g_why), sizeof(g_why) - strlen(g_why), "%s%s=%s(%d)",
+		 g_why[0] ? ", " : "", call, hipGetErrorName(herr), (int)herr);
+}
+
+static int
+bar_import_probe_import(int dmabuf_fd, size_t nbytes, uint64_t *devptr)
+{
+	hipExternalMemoryHandleDesc handle = {0};
+	hipExternalMemoryBufferDesc buffer = {0};
+	hipError_t herr;
+
+	handle.type = hipExternalMemoryHandleTypeOpaqueFd;
+	handle.handle.fd = dmabuf_fd;
+	handle.size = nbytes;
+
+	herr = hipImportExternalMemory(&g_extmem, &handle);
+	if (herr != hipSuccess) {
+		bar_import_probe_note("hipImportExternalMemory", herr);
+		return (int)herr;
+	}
+
+	buffer.offset = 0;
+	buffer.size = nbytes;
+
+	herr = hipExternalMemoryGetMappedBuffer(&g_devptr, g_extmem, &buffer);
+	if (herr != hipSuccess) {
+		bar_import_probe_note("hipExternalMemoryGetMappedBuffer", herr);
+		return (int)herr;
+	}
+
+	*devptr = (uint64_t)g_devptr;
+
+	return 0;
+}
+
+static int
+bar_import_probe_read(uint64_t devptr, size_t nbytes, void *dst)
+{
+	hipError_t herr = hipMemcpyDtoH(dst, (void *)devptr, nbytes);
+
+	return herr == hipSuccess ? 0 : (int)herr;
+}
+
+static void
+bar_import_probe_release(void)
+{
+	if (g_extmem) {
+		hipDestroyExternalMemory(g_extmem);
+		g_extmem = NULL;
+	}
+}
+
+static int
+bar_import_probe_selftest(char *why, size_t why_nbytes)
+{
+	snprintf(why, why_nbytes, "no dma-buf handle type in this runtime");
+
+	return -ENOTSUP;
+}
+
+#include "probe_vfio_bar_import.h"
+
+int
+main(int argc, char *argv[])
+{
+	return bar_import_probe_main(argc, argv);
+}

--- a/tools/upcie_probe_vfio_cdev.c
+++ b/tools/upcie_probe_vfio_cdev.c
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Can a second process open a vfio cdev already held by another, bind it to
+// its own iommufd, map memory, and reach the BAR?
+//
+//   vfio_cdev_probe <cdev> <attach:0|1> <hold-seconds>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <linux/vfio.h>
+#include <linux/iommufd.h>
+
+#define STEP(label, expr)                                                   \
+	do {                                                                \
+		long _rc = (long)(expr);                                    \
+		printf("  %-28s %s%s%s\n", label, _rc < 0 ? "FAIL " : "ok", \
+		       _rc < 0 ? strerror(errno) : "", _rc < 0 ? "" : "");  \
+	} while (0)
+
+int
+main(int argc, char **argv)
+{
+	const char *cdev = argc > 1 ? argv[1] : "/dev/vfio/devices/vfio0";
+	int do_attach = argc > 2 ? atoi(argv[2]) : 1;
+	int hold = argc > 3 ? atoi(argv[3]) : 0;
+	struct vfio_device_bind_iommufd bind = {.argsz = sizeof(bind)};
+	struct iommu_ioas_alloc alloc = {.size = sizeof(alloc)};
+	struct iommu_ioas_map map = {.size = sizeof(map)};
+	struct vfio_region_info reg = {.argsz = sizeof(reg)};
+	int dfd, ifd, rc;
+	void *buf, *bar;
+
+	printf("[pid %d] %s attach=%d\n", getpid(), cdev, do_attach);
+
+	dfd = open(cdev, O_RDWR);
+	printf("  %-28s %s\n", "open(cdev)", dfd < 0 ? strerror(errno) : "ok");
+	if (dfd < 0) {
+		return 1;
+	}
+
+	ifd = open("/dev/iommu", O_RDWR);
+	printf("  %-28s %s\n", "open(/dev/iommu)", ifd < 0 ? strerror(errno) : "ok");
+	if (ifd < 0) {
+		return 1;
+	}
+
+	bind.iommufd = ifd;
+	rc = ioctl(dfd, VFIO_DEVICE_BIND_IOMMUFD, &bind);
+	printf("  %-28s %s\n", "BIND_IOMMUFD", rc < 0 ? strerror(errno) : "ok");
+
+	rc = ioctl(ifd, IOMMU_IOAS_ALLOC, &alloc);
+	printf("  %-28s %s\n", "IOAS_ALLOC", rc < 0 ? strerror(errno) : "ok");
+
+	if (do_attach) {
+		struct vfio_device_attach_iommufd_pt att = {.argsz = sizeof(att)};
+
+		att.pt_id = alloc.out_ioas_id;
+		rc = ioctl(dfd, VFIO_DEVICE_ATTACH_IOMMUFD_PT, &att);
+		printf("  %-28s %s\n", "ATTACH_IOMMUFD_PT", rc < 0 ? strerror(errno) : "ok");
+	}
+
+	buf = mmap(NULL, 2 << 20, PROT_READ | PROT_WRITE,
+		   MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB, -1, 0);
+	if (buf == MAP_FAILED) {
+		buf = mmap(NULL, 2 << 20, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1,
+			   0);
+	}
+	map.ioas_id = alloc.out_ioas_id;
+	map.user_va = (unsigned long long)buf;
+	map.length = 2 << 20;
+	map.flags = IOMMU_IOAS_MAP_READABLE | IOMMU_IOAS_MAP_WRITEABLE;
+	rc = ioctl(ifd, IOMMU_IOAS_MAP, &map);
+	printf("  %-28s %s", "IOAS_MAP (2MiB)", rc < 0 ? strerror(errno) : "ok");
+	if (rc == 0) {
+		printf(" iova=0x%llx", (unsigned long long)map.iova);
+	}
+	printf("\n");
+
+	reg.index = VFIO_PCI_BAR0_REGION_INDEX;
+	rc = ioctl(dfd, VFIO_DEVICE_GET_REGION_INFO, &reg);
+	printf("  %-28s %s\n", "GET_REGION_INFO(BAR0)", rc < 0 ? strerror(errno) : "ok");
+	if (rc == 0) {
+		bar = mmap(NULL, reg.size, PROT_READ | PROT_WRITE, MAP_SHARED, dfd, reg.offset);
+		printf("  %-28s %s\n", "mmap(BAR0)", bar == MAP_FAILED ? strerror(errno) : "ok");
+		if (bar != MAP_FAILED) {
+			printf("  %-28s 0x%08x\n", "BAR0 dword0", *(volatile unsigned int *)bar);
+		}
+	}
+
+	if (hold) {
+		printf("  holding for %ds\n", hold);
+		fflush(stdout);
+		sleep(hold);
+	}
+
+	return 0;
+}

--- a/tools/upcie_probe_vfio_delegate.c
+++ b/tools/upcie_probe_vfio_delegate.c
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * Delegation probe: registration direction, and what survives the primary
+ * =======================================================================
+ *
+ * Two questions a design for sharing a controller has to answer, and neither
+ * is about GPUs, so neither needs one.
+ *
+ * The first is which way registration goes. A secondary holding the iommufd
+ * can map its own memory, which charges the pinned pages to the secondary; a
+ * secondary that only asks the primary to map a descriptor it sends charges
+ * them to the primary. Both are done here, in that order, so that lowering
+ * RLIMIT_MEMLOCK on either side shows which one it bounds.
+ *
+ * The second is what a secondary still has when the primary is gone. The
+ * primary exits after serving, and the secondary then re-reads a register
+ * through its own mapping and tries another mapping through the iommufd it was
+ * handed. A device fd keeps the device bound; whether the address space
+ * outlives the process that created it is the question the restart policy
+ * turns on.
+ *
+ * Usage:
+ *   upcie_probe_vfio_delegate primary <cdev> <socket>
+ *   upcie_probe_vfio_delegate secondary <socket>
+ *
+ * Run the primary in the background; it serves one secondary and exits. Lower
+ * the limit on either side to see the accounting move, for example with
+ * "sh -c 'ulimit -l 64; ... secondary ...'".
+ *
+ * @file upcie_probe_vfio_delegate.c
+ */
+
+#include <upcie/upcie.h>
+
+#include <sys/resource.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+
+#define PROBE_NBYTES (2 << 20)
+
+static void
+say(const char *who, const char *what, const char *how)
+{
+	printf("  [%s] %-30s %s\n", who, what, how);
+}
+
+static void
+say_limit(const char *who)
+{
+	struct rlimit rl = {0};
+	char note[64];
+
+	if (getrlimit(RLIMIT_MEMLOCK, &rl)) {
+		return;
+	}
+	if (rl.rlim_cur == RLIM_INFINITY) {
+		snprintf(note, sizeof(note), "unlimited");
+	} else {
+		snprintf(note, sizeof(note), "%llu bytes", (unsigned long long)rl.rlim_cur);
+	}
+	say(who, "RLIMIT_MEMLOCK", note);
+}
+
+static int
+send_fd(int sock, int fd, uint64_t val)
+{
+	char control[CMSG_SPACE(sizeof(int))] = {0};
+	struct iovec iov = {.iov_base = &val, .iov_len = sizeof(val)};
+	struct msghdr msg = {0};
+	struct cmsghdr *cmsg;
+
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	if (fd >= 0) {
+		msg.msg_control = control;
+		msg.msg_controllen = sizeof(control);
+		cmsg = CMSG_FIRSTHDR(&msg);
+		cmsg->cmsg_level = SOL_SOCKET;
+		cmsg->cmsg_type = SCM_RIGHTS;
+		cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+		memcpy(CMSG_DATA(cmsg), &fd, sizeof(int));
+	}
+
+	return sendmsg(sock, &msg, 0) < 0 ? -errno : 0;
+}
+
+static int
+recv_fd(int sock, int *fd, uint64_t *val)
+{
+	char control[CMSG_SPACE(sizeof(int))] = {0};
+	struct iovec iov = {.iov_base = val, .iov_len = sizeof(*val)};
+	struct msghdr msg = {0};
+	struct cmsghdr *cmsg;
+	ssize_t nbytes;
+
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+	msg.msg_control = control;
+	msg.msg_controllen = sizeof(control);
+
+	nbytes = recvmsg(sock, &msg, 0);
+	if (nbytes < 0) {
+		return -errno;
+	}
+	if (nbytes == 0) {
+		return -ENODATA;
+	}
+
+	if (fd) {
+		*fd = -1;
+		cmsg = CMSG_FIRSTHDR(&msg);
+		if (cmsg && cmsg->cmsg_type == SCM_RIGHTS) {
+			memcpy(fd, CMSG_DATA(cmsg), sizeof(int));
+		}
+	}
+
+	return 0;
+}
+
+static int
+memfd_of(size_t nbytes)
+{
+	int fd = memfd_create("delegate_probe", 0);
+
+	if (fd < 0) {
+		return -errno;
+	}
+	if (ftruncate(fd, (off_t)nbytes)) {
+		close(fd);
+		return -errno;
+	}
+
+	return fd;
+}
+
+static int
+secondary(const char *path)
+{
+	struct sockaddr_un addr = {.sun_family = AF_UNIX};
+	struct vfio_region_info region = {.index = 0};
+	struct iommufd iommufd = {0};
+	uint64_t iova = 0, ignored = 0;
+	int devfd = -1, iommu_fd = -1, memfd = -1;
+	void *bar0;
+	int sock;
+	int err;
+
+	say_limit("secondary");
+
+	sock = socket(AF_UNIX, SOCK_STREAM, 0);
+	snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", path);
+	if (sock < 0 || connect(sock, (struct sockaddr *)&addr, sizeof(addr))) {
+		say("secondary", "connect()", strerror(errno));
+		return -errno;
+	}
+
+	if (recv_fd(sock, &devfd, &ignored) || devfd < 0) {
+		say("secondary", "recv device fd", "FAILED");
+		return -EPROTO;
+	}
+	if (recv_fd(sock, &iommu_fd, &ignored) || iommu_fd < 0) {
+		say("secondary", "recv iommufd", "FAILED");
+		return -EPROTO;
+	}
+	say("secondary", "recv device fd and iommufd", "ok");
+
+	if (vfio_device_get_region_info(devfd, &region)) {
+		say("secondary", "GET_REGION_INFO(BAR0)", strerror(errno));
+		return -errno;
+	}
+	bar0 = vfio_map_region(devfd, region.size, region.offset);
+	if (bar0 == MAP_FAILED) {
+		say("secondary", "mmap(BAR0)", strerror(errno));
+		return -errno;
+	}
+	printf("  [secondary] %-30s 0x%08" PRIx32 "\n", "host read", mmio_read32(bar0, 0));
+
+	/* Direction one: the secondary maps its own memory through the passed
+	 * iommufd, which is what measurement 2 did. */
+	iommufd.fd = iommu_fd;
+	iommufd.ioas_id = (uint32_t)ignored;
+	memfd = memfd_of(PROBE_NBYTES);
+	if (memfd < 0) {
+		say("secondary", "memfd_create()", strerror(-memfd));
+		return memfd;
+	}
+
+	err = iommufd_ioas_map_file(&iommufd, memfd, 0, PROBE_NBYTES,
+				    IOMMU_IOAS_MAP_READABLE | IOMMU_IOAS_MAP_WRITEABLE, &iova);
+	if (err) {
+		say("secondary", "self map, charged to it", strerror(-err));
+	} else {
+		printf("  [secondary] %-30s ok, iova=0x%" PRIx64 "\n", "self map, charged to it",
+		       iova);
+	}
+
+	/* And the same memory as an anonymous mapping rather than a
+	 * descriptor, since the two are accounted differently and only this
+	 * one is what measurement 2 exercised. */
+	{
+		void *anon = mmap(NULL, PROBE_NBYTES, PROT_READ | PROT_WRITE,
+				  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		uint64_t anon_iova = 0;
+
+		if (anon == MAP_FAILED) {
+			say("secondary", "mmap(anonymous)", strerror(errno));
+		} else {
+			memset(anon, 0, PROBE_NBYTES);
+			err = iommufd_ioas_map(&iommufd, (uint64_t)anon, PROBE_NBYTES,
+					       IOMMU_IOAS_MAP_READABLE | IOMMU_IOAS_MAP_WRITEABLE,
+					       &anon_iova);
+			if (err) {
+				say("secondary", "self map, anonymous", strerror(-err));
+			} else {
+				printf("  [secondary] %-30s ok, iova=0x%" PRIx64 "\n",
+				       "self map, anonymous", anon_iova);
+			}
+		}
+	}
+
+	/* Direction two: hand the descriptor over and let the primary map it,
+	 * which is what the design proposes. */
+	err = send_fd(sock, memfd, PROBE_NBYTES);
+	if (err) {
+		say("secondary", "send memfd to primary", strerror(-err));
+		return err;
+	}
+	if (recv_fd(sock, NULL, &iova)) {
+		say("secondary", "primary maps it", "no answer");
+	} else if (!iova) {
+		say("secondary", "primary maps it", "refused");
+	} else {
+		printf("  [secondary] %-30s ok, iova=0x%" PRIx64 "\n", "primary maps it", iova);
+	}
+
+	/* The primary exits here; wait for it rather than racing. */
+	while (recv_fd(sock, NULL, &ignored) != -ENODATA) {
+	}
+	say("secondary", "primary is gone", "ok");
+
+	printf("  [secondary] %-30s 0x%08" PRIx32 "\n", "host read after", mmio_read32(bar0, 0));
+
+	close(memfd);
+	memfd = memfd_of(PROBE_NBYTES);
+	iova = 0;
+	err = iommufd_ioas_map_file(&iommufd, memfd, 0, PROBE_NBYTES,
+				    IOMMU_IOAS_MAP_READABLE | IOMMU_IOAS_MAP_WRITEABLE, &iova);
+	if (err) {
+		say("secondary", "map after, via passed fd", strerror(-err));
+	} else {
+		printf("  [secondary] %-30s ok, iova=0x%" PRIx64 "\n", "map after, via passed fd",
+		       iova);
+	}
+
+	return 0;
+}
+
+static int
+primary(const char *cdev, const char *path)
+{
+	struct sockaddr_un addr = {.sun_family = AF_UNIX};
+	struct iommufd iommufd = {0};
+	struct vfio_cdev dev = {0};
+	uint64_t iova = 0, nbytes = 0;
+	int listener, sock, memfd = -1;
+	int err;
+
+	say_limit("primary");
+
+	err = iommufd_open(&iommufd);
+	if (!err) {
+		err = iommufd_ioas_alloc(&iommufd);
+	}
+	if (!err) {
+		err = vfio_cdev_open(cdev, &dev);
+	}
+	if (!err) {
+		err = iommufd_bind(&iommufd, &dev);
+	}
+	if (!err) {
+		err = iommufd_attach(&iommufd, &dev);
+	}
+	if (err) {
+		say("primary", "device setup", strerror(-err));
+		return err;
+	}
+	say("primary", "bind and attach", "ok");
+
+	unlink(path);
+	listener = socket(AF_UNIX, SOCK_STREAM, 0);
+	snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", path);
+	if (listener < 0 || bind(listener, (struct sockaddr *)&addr, sizeof(addr)) ||
+	    listen(listener, 1) || chmod(path, 0666)) {
+		say("primary", "listen()", strerror(errno));
+		return -errno;
+	}
+	say("primary", "listening", path);
+
+	sock = accept(listener, NULL, NULL);
+	if (sock < 0) {
+		say("primary", "accept()", strerror(errno));
+		return -errno;
+	}
+
+	if (send_fd(sock, dev.fd, 0) || send_fd(sock, iommufd.fd, iommufd.ioas_id)) {
+		say("primary", "send descriptors", "FAILED");
+		return -EIO;
+	}
+	say("primary", "send device fd and iommufd", "ok");
+
+	if (recv_fd(sock, &memfd, &nbytes) || memfd < 0) {
+		say("primary", "recv memfd", "FAILED");
+		return -EPROTO;
+	}
+
+	err = iommufd_ioas_map_file(&iommufd, memfd, 0, nbytes,
+				    IOMMU_IOAS_MAP_READABLE | IOMMU_IOAS_MAP_WRITEABLE, &iova);
+	if (err) {
+		say("primary", "map on its behalf", strerror(-err));
+		iova = 0;
+	} else {
+		printf("  [primary]   %-30s ok, iova=0x%" PRIx64 "\n", "map on its behalf", iova);
+	}
+	send_fd(sock, -1, iova);
+
+	say("primary", "exiting", "ok");
+	close(memfd);
+	close(sock);
+	close(listener);
+	unlink(path);
+	iommufd_detach(&dev);
+	vfio_cdev_close(&dev);
+	iommufd_close(&iommufd);
+
+	return 0;
+}
+
+int
+main(int argc, char *argv[])
+{
+	setvbuf(stdout, NULL, _IOLBF, 0);
+
+	if (argc == 4 && !strcmp(argv[1], "primary")) {
+		return primary(argv[2], argv[3]) ? EXIT_FAILURE : EXIT_SUCCESS;
+	}
+	if (argc == 3 && !strcmp(argv[1], "secondary")) {
+		return secondary(argv[2]) ? EXIT_FAILURE : EXIT_SUCCESS;
+	}
+
+	fprintf(stderr, "usage: %s primary <cdev> <socket>\n", argv[0]);
+	fprintf(stderr, "       %s secondary <socket>\n", argv[0]);
+
+	return 2;
+}

--- a/tools/upcie_probe_vfio_share.c
+++ b/tools/upcie_probe_vfio_share.c
@@ -1,0 +1,246 @@
+// SPDX-FileCopyrightText: Samsung Electronics Co., Ltd
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Can a privileged primary hand a vfio-pci device to an unprivileged secondary?
+//
+//   vfio_share primary   <cdev> <sock>
+//   vfio_share secondary <sock>
+//
+// The primary binds the device, maps a memfd into its IOAS, then passes the
+// device fd, the iommufd and the memfd over a unix socket. The secondary, which
+// need not be root, tries to reach the BAR and register memory of its own.
+
+// syscall(2) and ftruncate(2) are not declared under -std=c11 alone, and this
+// probe deliberately includes no uPCIe header, since what it asks about is raw
+// kernel behaviour.
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <linux/vfio.h>
+#include <linux/iommufd.h>
+
+#define R(l, rc) printf("  %-30s %s\n", l, (long)(rc) < 0 ? strerror(errno) : "ok")
+
+static int
+send_fds(int sock, int *fds, int n)
+{
+	struct msghdr msg = {0};
+	struct iovec io = {.iov_base = "x", .iov_len = 1};
+	char buf[CMSG_SPACE(sizeof(int) * 4)] = {0};
+	struct cmsghdr *cm;
+
+	msg.msg_iov = &io;
+	msg.msg_iovlen = 1;
+	msg.msg_control = buf;
+	msg.msg_controllen = CMSG_SPACE(sizeof(int) * n);
+	cm = CMSG_FIRSTHDR(&msg);
+	cm->cmsg_level = SOL_SOCKET;
+	cm->cmsg_type = SCM_RIGHTS;
+	cm->cmsg_len = CMSG_LEN(sizeof(int) * n);
+	memcpy(CMSG_DATA(cm), fds, sizeof(int) * n);
+
+	return sendmsg(sock, &msg, 0);
+}
+
+static int
+recv_fds(int sock, int *fds, int n)
+{
+	struct msghdr msg = {0};
+	struct iovec io = {0};
+	char c, buf[CMSG_SPACE(sizeof(int) * 4)] = {0};
+	struct cmsghdr *cm;
+
+	io.iov_base = &c;
+	io.iov_len = 1;
+	msg.msg_iov = &io;
+	msg.msg_iovlen = 1;
+	msg.msg_control = buf;
+	msg.msg_controllen = sizeof(buf);
+	if (recvmsg(sock, &msg, 0) < 0) {
+		return -1;
+	}
+	cm = CMSG_FIRSTHDR(&msg);
+	if (!cm) {
+		return -1;
+	}
+	memcpy(fds, CMSG_DATA(cm), sizeof(int) * n);
+
+	return 0;
+}
+
+static int
+bar_probe(int dfd, const char *who)
+{
+	struct vfio_region_info reg = {.argsz = sizeof(reg)};
+	void *bar;
+	int rc;
+
+	reg.index = VFIO_PCI_BAR0_REGION_INDEX;
+	rc = ioctl(dfd, VFIO_DEVICE_GET_REGION_INFO, &reg);
+	R("GET_REGION_INFO(BAR0)", rc);
+	if (rc < 0) {
+		return -1;
+	}
+	bar = mmap(NULL, reg.size, PROT_READ | PROT_WRITE, MAP_SHARED, dfd, reg.offset);
+	R("mmap(BAR0)", bar == MAP_FAILED ? -1 : 0);
+	if (bar == MAP_FAILED) {
+		return -1;
+	}
+	printf("  %-30s 0x%08x   (%s)\n", "NVMe CAP low dword", *(volatile unsigned int *)bar,
+	       who);
+
+	return 0;
+}
+
+/*
+ * Map a memfd into the IOAS, and say which way it was done.
+ *
+ * IOMMU_IOAS_MAP_FILE arrived in Linux 6.14, and distributions still shipping
+ * older UAPI headers cannot see it at build time even where the running kernel
+ * has it. Falling back to IOMMU_IOAS_MAP over a host mapping of the same memfd
+ * keeps the question this probe asks answerable there.
+ */
+#ifdef IOMMU_IOAS_MAP_FILE
+#define IOAS_MAP_MEMFD "IOAS_MAP_FILE(memfd)"
+static int
+ioas_map_memfd(int ifd, unsigned int ioas_id, int mfd, unsigned long long *iova)
+{
+	struct iommu_ioas_map_file mf = {.size = sizeof(mf)};
+
+	mf.ioas_id = ioas_id;
+	mf.fd = mfd;
+	mf.start = 0;
+	mf.length = 2 << 20;
+	mf.flags = IOMMU_IOAS_MAP_READABLE | IOMMU_IOAS_MAP_WRITEABLE;
+	if (ioctl(ifd, IOMMU_IOAS_MAP_FILE, &mf) == -1) {
+		return -1;
+	}
+	*iova = mf.iova;
+
+	return 0;
+}
+#else
+#define IOAS_MAP_MEMFD "IOAS_MAP(memfd via user_va)"
+static int
+ioas_map_memfd(int ifd, unsigned int ioas_id, int mfd, unsigned long long *iova)
+{
+	struct iommu_ioas_map m = {.size = sizeof(m)};
+	void *va = mmap(NULL, 2 << 20, PROT_READ | PROT_WRITE, MAP_SHARED, mfd, 0);
+
+	if (va == MAP_FAILED) {
+		return -1;
+	}
+	m.ioas_id = ioas_id;
+	m.user_va = (unsigned long long)va;
+	m.length = 2 << 20;
+	m.flags = IOMMU_IOAS_MAP_READABLE | IOMMU_IOAS_MAP_WRITEABLE;
+	if (ioctl(ifd, IOMMU_IOAS_MAP, &m) == -1) {
+		return -1;
+	}
+	*iova = m.iova;
+
+	return 0;
+}
+#endif
+
+int
+main(int argc, char **argv)
+{
+	const char *role = argc > 1 ? argv[1] : "";
+	struct sockaddr_un sa = {.sun_family = AF_UNIX};
+	int sock, fds[3];
+
+	if (!strcmp(role, "primary")) {
+		const char *cdev = argv[2];
+		struct vfio_device_bind_iommufd bnd = {.argsz = sizeof(bnd)};
+		struct iommu_ioas_alloc alloc = {.size = sizeof(alloc)};
+		struct vfio_device_attach_iommufd_pt att = {.argsz = sizeof(att)};
+		unsigned long long iova = 0;
+		int dfd, ifd, mfd, cl;
+
+		printf("[primary uid=%d]\n", getuid());
+		dfd = open(cdev, O_RDWR);
+		R("open(cdev)", dfd);
+		ifd = open("/dev/iommu", O_RDWR);
+		R("open(/dev/iommu)", ifd);
+		bnd.iommufd = ifd;
+		R("BIND_IOMMUFD", ioctl(dfd, VFIO_DEVICE_BIND_IOMMUFD, &bnd));
+		R("IOAS_ALLOC", ioctl(ifd, IOMMU_IOAS_ALLOC, &alloc));
+		printf("  %-30s %u\n", "ioas_id", alloc.out_ioas_id);
+		fflush(stdout);
+		att.pt_id = alloc.out_ioas_id;
+		R("ATTACH_IOMMUFD_PT", ioctl(dfd, VFIO_DEVICE_ATTACH_IOMMUFD_PT, &att));
+
+		mfd = syscall(SYS_memfd_create, "dma", 0);
+		R("memfd_create", mfd);
+		R("ftruncate(2MiB)", ftruncate(mfd, 2 << 20));
+		R(IOAS_MAP_MEMFD, ioas_map_memfd(ifd, alloc.out_ioas_id, mfd, &iova));
+		printf("  %-30s 0x%llx\n", "  -> iova", iova);
+		bar_probe(dfd, "primary");
+
+		unlink(argv[3]);
+		sock = socket(AF_UNIX, SOCK_STREAM, 0);
+		strncpy(sa.sun_path, argv[3], sizeof(sa.sun_path) - 1);
+		(void)bind(sock, (struct sockaddr *)&sa, sizeof(sa));
+		listen(sock, 1);
+		chmod(argv[3], 0666);
+		printf("  waiting for secondary...\n");
+		fflush(stdout);
+		cl = accept(sock, NULL, NULL);
+		fds[0] = dfd;
+		fds[1] = ifd;
+		fds[2] = mfd;
+		R("send fds", send_fds(cl, fds, 3));
+		fflush(stdout);
+		sleep(8);
+
+		return 0;
+	}
+
+	printf("[secondary uid=%d]\n", getuid());
+	sock = socket(AF_UNIX, SOCK_STREAM, 0);
+	strncpy(sa.sun_path, argv[2], sizeof(sa.sun_path) - 1);
+	R("connect", connect(sock, (struct sockaddr *)&sa, sizeof(sa)));
+	R("recv fds", recv_fds(sock, fds, 3));
+	printf("  device fd=%d iommufd=%d memfd=%d\n", fds[0], fds[1], fds[2]);
+
+	bar_probe(fds[0], "secondary");
+
+	{
+		void *p = mmap(NULL, 2 << 20, PROT_READ | PROT_WRITE, MAP_SHARED, fds[2], 0);
+		R("mmap(shared memfd)", p == MAP_FAILED ? -1 : 0);
+		if (p != MAP_FAILED) {
+			*(volatile unsigned int *)p = 0xC0FFEE;
+			printf("  %-30s wrote 0x%08x\n", "shared DMA buffer",
+			       *(volatile unsigned int *)p);
+		}
+	}
+	{
+		struct iommu_ioas_map m = {.size = sizeof(m)};
+		void *own = mmap(NULL, 2 << 20, PROT_READ | PROT_WRITE,
+				 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+		m.ioas_id = argc > 3 ? (unsigned)atoi(argv[3]) : 0;
+		m.user_va = (unsigned long long)own;
+		m.length = 2 << 20;
+		m.flags = IOMMU_IOAS_MAP_READABLE | IOMMU_IOAS_MAP_WRITEABLE;
+		R("IOAS_MAP own buffer", ioctl(fds[1], IOMMU_IOAS_MAP, &m));
+		if (m.iova) {
+			printf("  %-30s 0x%llx\n", "  -> iova", (unsigned long long)m.iova);
+		}
+	}
+
+	return 0;
+}

--- a/tools/upcie_probe_vfio_share_gpu_cuda.c
+++ b/tools/upcie_probe_vfio_share_gpu_cuda.c
@@ -1,0 +1,421 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * Delegated MMIO probe: can a secondary reach the BAR from a GPU kernel?
+ * =====================================================================
+ *
+ * A process can pass a vfio device fd to an unrelated process over SCM_RIGHTS,
+ * and the receiver can map BAR0 and read a register. What that leaves untested
+ * is the step the GPU-initiated NVMe path depends on: registering a window of
+ * that received mapping as I/O memory with cuMemHostRegister(), and reaching
+ * it from an SM.
+ *
+ * Two processes rather than a fork with a setuid in it. Dropping privilege is
+ * not the same state as never having had it: the dropped process keeps the
+ * supplementary groups it was started with unless they are cleared, and a uid
+ * change clears the dumpable flag, either of which could be what a refusal is
+ * really about. So the secondary is started separately, as whatever user it is
+ * started as, and the two meet over a named socket.
+ *
+ * It reads CAP rather than writing a doorbell, so nothing here disturbs a
+ * controller, and both sides print what they read.
+ *
+ * Usage:
+ *   upcie_probe_vfio_share_gpu_cuda primary <cdev> <socket>
+ *   upcie_probe_vfio_share_gpu_cuda secondary <socket>
+ *   upcie_probe_vfio_share_gpu_cuda standalone <cdev>
+ *
+ * The standalone mode is the control: no delegation, the process opens the
+ * device itself. Run as an ordinary user it says whether a refusal is about
+ * the caller or about the descriptor having been passed.
+ *
+ * The primary serves one secondary and exits when it disconnects, so run it in
+ * the background and start the secondary as the user in question, for example
+ * with setpriv --reuid=1000 --regid=1000 --clear-groups.
+ *
+ * @file upcie_probe_vfio_share_gpu_cuda.c
+ */
+
+/* upcie.h sets the feature-test macros, so it comes before anything that
+ * pulls in features.h. */
+#include <upcie/upcie_cuda.h>
+
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+
+int
+upcie_probe_read_mmio(const void *mmio, uint32_t *out);
+
+static void
+say(const char *who, const char *what, const char *how)
+{
+	printf("  [%s] %-28s %s\n", who, what, how);
+}
+
+static int
+send_fd(int sock, int fd)
+{
+	char control[CMSG_SPACE(sizeof(int))] = {0};
+	struct iovec iov = {.iov_base = (void *)"f", .iov_len = 1};
+	struct msghdr msg = {0};
+	struct cmsghdr *cmsg;
+
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+	msg.msg_control = control;
+	msg.msg_controllen = sizeof(control);
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_RIGHTS;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+	memcpy(CMSG_DATA(cmsg), &fd, sizeof(int));
+
+	return sendmsg(sock, &msg, 0) < 0 ? -errno : 0;
+}
+
+static int
+recv_fd(int sock, int *fd)
+{
+	char control[CMSG_SPACE(sizeof(int))] = {0};
+	char byte = 0;
+	struct iovec iov = {.iov_base = &byte, .iov_len = 1};
+	struct msghdr msg = {0};
+	struct cmsghdr *cmsg;
+
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+	msg.msg_control = control;
+	msg.msg_controllen = sizeof(control);
+
+	if (recvmsg(sock, &msg, 0) < 0) {
+		return -errno;
+	}
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	if (!cmsg || cmsg->cmsg_type != SCM_RIGHTS) {
+		return -EPROTO;
+	}
+	memcpy(fd, CMSG_DATA(cmsg), sizeof(int));
+
+	return 0;
+}
+
+/**
+ * What a process does with a device fd, however it came by one.
+ */
+static int
+use_bar(const char *who, int fd, uint64_t offset)
+{
+	struct vfio_region_info region = {.index = 0};
+	uint32_t gpu[2] = {0};
+	CUcontext ctx;
+	CUdevice cudev;
+	void *bar0;
+	int err;
+
+	if (vfio_device_get_region_info(fd, &region)) {
+		say(who, "GET_REGION_INFO(BAR0)", strerror(errno));
+		return -errno;
+	}
+
+	bar0 = vfio_map_region(fd, region.size, region.offset);
+	if (bar0 == MAP_FAILED) {
+		say(who, "mmap(BAR0)", strerror(errno));
+		return -errno;
+	}
+	printf("  [%s] %-28s 0x%08" PRIx32 " 0x%08" PRIx32 "\n", who, "host read",
+	       mmio_read32(bar0, offset), mmio_read32(bar0, offset + 4));
+
+	if (cuInit(0) || cuDeviceGet(&cudev, 0) || cuDevicePrimaryCtxRetain(&ctx, cudev) ||
+	    cuCtxSetCurrent(ctx)) {
+		say(who, "CUDA init", "FAILED");
+		return -EIO;
+	}
+
+	/* The step this probe exists for: the shipping GPU-initiated path
+	 * registers a doorbell the same way. */
+	err = (int)cuMemHostRegister((uint8_t *)bar0 + offset, 2 * sizeof(uint32_t),
+				     CU_MEMHOSTREGISTER_IOMEMORY);
+	if (err) {
+		const char *name = NULL;
+
+		cuGetErrorName((CUresult)err, &name);
+		say(who, "cuMemHostRegister(IOMEMORY)", name ? name : "FAILED");
+		return -EIO;
+	}
+	say(who, "cuMemHostRegister(IOMEMORY)", "ok");
+
+	err = upcie_probe_read_mmio((uint8_t *)bar0 + offset, gpu);
+	if (err) {
+		say(who, "kernel read", "FAILED");
+		return -EIO;
+	}
+	printf("  [%s] %-28s 0x%08" PRIx32 " 0x%08" PRIx32 "\n", who, "kernel read", gpu[0],
+	       gpu[1]);
+
+	return 0;
+}
+
+static void
+say_creds(const char *who)
+{
+	char note[96];
+
+	snprintf(note, sizeof(note), "uid=%u euid=%u gid=%u", (unsigned)getuid(),
+		 (unsigned)geteuid(), (unsigned)getgid());
+	say(who, "running as", note);
+}
+
+/**
+ * The secondary: a received descriptor and nothing else.
+ */
+static int
+secondary(int sock, uint64_t offset)
+{
+	int fd = -1;
+	int err;
+
+	say_creds("secondary");
+
+	err = recv_fd(sock, &fd);
+	if (err) {
+		say("secondary", "recv device fd", strerror(-err));
+		return err;
+	}
+	say("secondary", "recv device fd", "ok");
+
+	return use_bar("secondary", fd, offset);
+}
+
+/**
+ * Standalone: no delegation at all, the process opens the device itself.
+ *
+ * This is the control for the secondary's result. If it is refused the same
+ * way, the refusal is about the calling process rather than about the
+ * descriptor having been passed to it. Needs the cdev and /dev/iommu to be
+ * reachable by whoever runs it.
+ */
+static int
+standalone(const char *cdev, uint64_t offset)
+{
+	struct iommufd iommufd = {0};
+	struct vfio_cdev dev = {0};
+	int err;
+
+	say_creds("standalone");
+
+	err = iommufd_open(&iommufd);
+	if (err) {
+		say("standalone", "iommufd_open()", strerror(-err));
+		return err;
+	}
+
+	err = iommufd_ioas_alloc(&iommufd);
+	if (err) {
+		say("standalone", "iommufd_ioas_alloc()", strerror(-err));
+		return err;
+	}
+
+	err = vfio_cdev_open(cdev, &dev);
+	if (err) {
+		say("standalone", "vfio_cdev_open()", strerror(-err));
+		return err;
+	}
+
+	err = iommufd_bind(&iommufd, &dev);
+	if (err) {
+		say("standalone", "iommufd_bind()", strerror(-err));
+		return err;
+	}
+
+	err = iommufd_attach(&iommufd, &dev);
+	if (err) {
+		say("standalone", "iommufd_attach()", strerror(-err));
+		return err;
+	}
+	say("standalone", "bind and attach", "ok");
+
+	return use_bar("standalone", dev.fd, offset);
+}
+
+static int
+listen_at(const char *path)
+{
+	struct sockaddr_un addr = {.sun_family = AF_UNIX};
+	int sock;
+
+	unlink(path);
+
+	sock = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (sock < 0) {
+		return -errno;
+	}
+
+	snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", path);
+
+	if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) || listen(sock, 1)) {
+		close(sock);
+		return -errno;
+	}
+
+	/* The secondary is another user; the socket has to be reachable by it. */
+	if (chmod(path, 0666)) {
+		close(sock);
+		return -errno;
+	}
+
+	return sock;
+}
+
+static int
+connect_to(const char *path)
+{
+	struct sockaddr_un addr = {.sun_family = AF_UNIX};
+	int sock;
+
+	sock = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (sock < 0) {
+		return -errno;
+	}
+
+	snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", path);
+
+	if (connect(sock, (struct sockaddr *)&addr, sizeof(addr))) {
+		close(sock);
+		return -errno;
+	}
+
+	return sock;
+}
+
+/**
+ * The primary: holds the device, hands over the descriptor, serves one
+ * secondary and leaves when it disconnects.
+ */
+static int
+primary(const char *cdev, const char *path, uint64_t offset)
+{
+	struct vfio_region_info region = {.index = 0};
+	struct iommufd iommufd = {0};
+	struct vfio_cdev dev = {0};
+	char byte;
+	void *bar0;
+	int listener = -1, sock = -1;
+	int err;
+
+	err = iommufd_open(&iommufd);
+	if (err) {
+		say("primary", "iommufd_open()", strerror(-err));
+		return err;
+	}
+
+	err = iommufd_ioas_alloc(&iommufd);
+	if (err) {
+		say("primary", "iommufd_ioas_alloc()", strerror(-err));
+		return err;
+	}
+
+	err = vfio_cdev_open(cdev, &dev);
+	if (err) {
+		say("primary", "vfio_cdev_open()", strerror(-err));
+		return err;
+	}
+
+	err = iommufd_bind(&iommufd, &dev);
+	if (err) {
+		say("primary", "iommufd_bind()", strerror(-err));
+		return err;
+	}
+
+	err = iommufd_attach(&iommufd, &dev);
+	if (err) {
+		say("primary", "iommufd_attach()", strerror(-err));
+		return err;
+	}
+	say("primary", "bind and attach", "ok");
+
+	if (vfio_device_get_region_info(dev.fd, &region)) {
+		say("primary", "GET_REGION_INFO(BAR0)", strerror(errno));
+		return -errno;
+	}
+
+	bar0 = vfio_map_region(dev.fd, region.size, region.offset);
+	if (bar0 == MAP_FAILED) {
+		say("primary", "mmap(BAR0)", strerror(errno));
+		return -errno;
+	}
+	printf("  [primary]   %-28s 0x%08" PRIx32 " 0x%08" PRIx32 "\n", "host read",
+	       mmio_read32(bar0, offset), mmio_read32(bar0, offset + 4));
+
+	listener = listen_at(path);
+	if (listener < 0) {
+		say("primary", "listen()", strerror(-listener));
+		return listener;
+	}
+	say("primary", "listening", path);
+
+	sock = accept(listener, NULL, NULL);
+	if (sock < 0) {
+		say("primary", "accept()", strerror(errno));
+		close(listener);
+		return -errno;
+	}
+
+	err = send_fd(sock, dev.fd);
+	if (err) {
+		say("primary", "send device fd", strerror(-err));
+		close(sock);
+		close(listener);
+		return err;
+	}
+	say("primary", "send device fd", "ok");
+
+	/* Hold everything open until the secondary is done with it. */
+	while (read(sock, &byte, 1) > 0) {
+	}
+	say("primary", "secondary disconnected", "ok");
+
+	close(sock);
+	close(listener);
+	unlink(path);
+
+	return 0;
+}
+
+int
+main(int argc, char *argv[])
+{
+	const uint64_t offset = 0;
+	int err;
+
+	setvbuf(stdout, NULL, _IOLBF, 0);
+
+	if (argc == 4 && !strcmp(argv[1], "primary")) {
+		printf("vfio_share_gpu_probe primary: %s\n", argv[2]);
+		err = primary(argv[2], argv[3], offset);
+	} else if (argc == 3 && !strcmp(argv[1], "standalone")) {
+		printf("vfio_share_gpu_probe standalone: %s\n", argv[2]);
+		err = standalone(argv[2], offset);
+	} else if (argc == 3 && !strcmp(argv[1], "secondary")) {
+		int sock = connect_to(argv[2]);
+
+		printf("vfio_share_gpu_probe secondary: %s\n", argv[2]);
+		if (sock < 0) {
+			say("secondary", "connect()", strerror(-sock));
+			return EXIT_FAILURE;
+		}
+
+		err = secondary(sock, offset);
+		close(sock);
+	} else {
+		fprintf(stderr, "usage: %s primary <cdev> <socket>\n", argv[0]);
+		fprintf(stderr, "       %s secondary <socket>\n", argv[0]);
+		fprintf(stderr, "       %s standalone <cdev>\n", argv[0]);
+		return 2;
+	}
+
+	return err ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/tools/upcie_probe_vfio_share_gpu_cuda.c
+++ b/tools/upcie_probe_vfio_share_gpu_cuda.c
@@ -2,8 +2,7 @@
 // Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
 
 /**
- * Delegated MMIO probe: can a secondary reach the BAR from a GPU kernel?
- * =====================================================================
+ * Delegated MMIO probe, CUDA flavour
  *
  * A process can pass a vfio device fd to an unrelated process over SCM_RIGHTS,
  * and the receiver can map BAR0 and read a register. What that leaves untested
@@ -35,387 +34,73 @@
  * with setpriv --reuid=1000 --regid=1000 --clear-groups.
  *
  * @file upcie_probe_vfio_share_gpu_cuda.c
+ * See tools/README.md.
  */
 
-/* upcie.h sets the feature-test macros, so it comes before anything that
- * pulls in features.h. */
 #include <upcie/upcie_cuda.h>
 
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/un.h>
 
+#define SHARE_PROBE_REGISTER_NAME "cuMemHostRegister(IOMEMORY)"
+#define SHARE_PROBE_READ_NAME "kernel read"
+
 int
 upcie_probe_read_mmio(const void *mmio, uint32_t *out);
 
-static void
-say(const char *who, const char *what, const char *how)
+static char g_why[64];
+
+static const char *
+share_probe_why(void)
 {
-	printf("  [%s] %-28s %s\n", who, what, how);
+	return g_why;
 }
 
 static int
-send_fd(int sock, int fd)
+share_probe_rt_init(void)
 {
-	char control[CMSG_SPACE(sizeof(int))] = {0};
-	struct iovec iov = {.iov_base = (void *)"f", .iov_len = 1};
-	struct msghdr msg = {0};
-	struct cmsghdr *cmsg;
-
-	msg.msg_iov = &iov;
-	msg.msg_iovlen = 1;
-	msg.msg_control = control;
-	msg.msg_controllen = sizeof(control);
-
-	cmsg = CMSG_FIRSTHDR(&msg);
-	cmsg->cmsg_level = SOL_SOCKET;
-	cmsg->cmsg_type = SCM_RIGHTS;
-	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
-	memcpy(CMSG_DATA(cmsg), &fd, sizeof(int));
-
-	return sendmsg(sock, &msg, 0) < 0 ? -errno : 0;
-}
-
-static int
-recv_fd(int sock, int *fd)
-{
-	char control[CMSG_SPACE(sizeof(int))] = {0};
-	char byte = 0;
-	struct iovec iov = {.iov_base = &byte, .iov_len = 1};
-	struct msghdr msg = {0};
-	struct cmsghdr *cmsg;
-
-	msg.msg_iov = &iov;
-	msg.msg_iovlen = 1;
-	msg.msg_control = control;
-	msg.msg_controllen = sizeof(control);
-
-	if (recvmsg(sock, &msg, 0) < 0) {
-		return -errno;
-	}
-
-	cmsg = CMSG_FIRSTHDR(&msg);
-	if (!cmsg || cmsg->cmsg_type != SCM_RIGHTS) {
-		return -EPROTO;
-	}
-	memcpy(fd, CMSG_DATA(cmsg), sizeof(int));
-
-	return 0;
-}
-
-/**
- * What a process does with a device fd, however it came by one.
- */
-static int
-use_bar(const char *who, int fd, uint64_t offset)
-{
-	struct vfio_region_info region = {.index = 0};
-	uint32_t gpu[2] = {0};
 	CUcontext ctx;
-	CUdevice cudev;
-	void *bar0;
-	int err;
+	CUdevice dev;
 
-	if (vfio_device_get_region_info(fd, &region)) {
-		say(who, "GET_REGION_INFO(BAR0)", strerror(errno));
-		return -errno;
-	}
-
-	bar0 = vfio_map_region(fd, region.size, region.offset);
-	if (bar0 == MAP_FAILED) {
-		say(who, "mmap(BAR0)", strerror(errno));
-		return -errno;
-	}
-	printf("  [%s] %-28s 0x%08" PRIx32 " 0x%08" PRIx32 "\n", who, "host read",
-	       mmio_read32(bar0, offset), mmio_read32(bar0, offset + 4));
-
-	if (cuInit(0) || cuDeviceGet(&cudev, 0) || cuDevicePrimaryCtxRetain(&ctx, cudev) ||
+	if (cuInit(0) || cuDeviceGet(&dev, 0) || cuDevicePrimaryCtxRetain(&ctx, dev) ||
 	    cuCtxSetCurrent(ctx)) {
-		say(who, "CUDA init", "FAILED");
 		return -EIO;
 	}
-
-	/* The step this probe exists for: the shipping GPU-initiated path
-	 * registers a doorbell the same way. */
-	err = (int)cuMemHostRegister((uint8_t *)bar0 + offset, 2 * sizeof(uint32_t),
-				     CU_MEMHOSTREGISTER_IOMEMORY);
-	if (err) {
-		const char *name = NULL;
-
-		cuGetErrorName((CUresult)err, &name);
-		say(who, "cuMemHostRegister(IOMEMORY)", name ? name : "FAILED");
-		return -EIO;
-	}
-	say(who, "cuMemHostRegister(IOMEMORY)", "ok");
-
-	err = upcie_probe_read_mmio((uint8_t *)bar0 + offset, gpu);
-	if (err) {
-		say(who, "kernel read", "FAILED");
-		return -EIO;
-	}
-	printf("  [%s] %-28s 0x%08" PRIx32 " 0x%08" PRIx32 "\n", who, "kernel read", gpu[0],
-	       gpu[1]);
 
 	return 0;
 }
 
-static void
-say_creds(const char *who)
+static int
+share_probe_register(void *addr, size_t nbytes)
 {
-	char note[96];
+	CUresult cr = cuMemHostRegister(addr, nbytes, CU_MEMHOSTREGISTER_IOMEMORY);
+	const char *name = NULL;
 
-	snprintf(note, sizeof(note), "uid=%u euid=%u gid=%u", (unsigned)getuid(),
-		 (unsigned)geteuid(), (unsigned)getgid());
-	say(who, "running as", note);
+	if (cr == CUDA_SUCCESS) {
+		return 0;
+	}
+
+	cuGetErrorName(cr, &name);
+	snprintf(g_why, sizeof(g_why), "%s", name ? name : "FAILED");
+
+	return (int)cr;
 }
 
 /**
- * The secondary: a received descriptor and nothing else.
+ * The read comes from an SM, since the copy engine is not what rings a
+ * doorbell.
  */
 static int
-secondary(int sock, uint64_t offset)
+share_probe_read(const void *addr, uint32_t *out)
 {
-	int fd = -1;
-	int err;
-
-	say_creds("secondary");
-
-	err = recv_fd(sock, &fd);
-	if (err) {
-		say("secondary", "recv device fd", strerror(-err));
-		return err;
-	}
-	say("secondary", "recv device fd", "ok");
-
-	return use_bar("secondary", fd, offset);
+	return upcie_probe_read_mmio(addr, out);
 }
 
-/**
- * Standalone: no delegation at all, the process opens the device itself.
- *
- * This is the control for the secondary's result. If it is refused the same
- * way, the refusal is about the calling process rather than about the
- * descriptor having been passed to it. Needs the cdev and /dev/iommu to be
- * reachable by whoever runs it.
- */
-static int
-standalone(const char *cdev, uint64_t offset)
-{
-	struct iommufd iommufd = {0};
-	struct vfio_cdev dev = {0};
-	int err;
-
-	say_creds("standalone");
-
-	err = iommufd_open(&iommufd);
-	if (err) {
-		say("standalone", "iommufd_open()", strerror(-err));
-		return err;
-	}
-
-	err = iommufd_ioas_alloc(&iommufd);
-	if (err) {
-		say("standalone", "iommufd_ioas_alloc()", strerror(-err));
-		return err;
-	}
-
-	err = vfio_cdev_open(cdev, &dev);
-	if (err) {
-		say("standalone", "vfio_cdev_open()", strerror(-err));
-		return err;
-	}
-
-	err = iommufd_bind(&iommufd, &dev);
-	if (err) {
-		say("standalone", "iommufd_bind()", strerror(-err));
-		return err;
-	}
-
-	err = iommufd_attach(&iommufd, &dev);
-	if (err) {
-		say("standalone", "iommufd_attach()", strerror(-err));
-		return err;
-	}
-	say("standalone", "bind and attach", "ok");
-
-	return use_bar("standalone", dev.fd, offset);
-}
-
-static int
-listen_at(const char *path)
-{
-	struct sockaddr_un addr = {.sun_family = AF_UNIX};
-	int sock;
-
-	unlink(path);
-
-	sock = socket(AF_UNIX, SOCK_STREAM, 0);
-	if (sock < 0) {
-		return -errno;
-	}
-
-	snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", path);
-
-	if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) || listen(sock, 1)) {
-		close(sock);
-		return -errno;
-	}
-
-	/* The secondary is another user; the socket has to be reachable by it. */
-	if (chmod(path, 0666)) {
-		close(sock);
-		return -errno;
-	}
-
-	return sock;
-}
-
-static int
-connect_to(const char *path)
-{
-	struct sockaddr_un addr = {.sun_family = AF_UNIX};
-	int sock;
-
-	sock = socket(AF_UNIX, SOCK_STREAM, 0);
-	if (sock < 0) {
-		return -errno;
-	}
-
-	snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", path);
-
-	if (connect(sock, (struct sockaddr *)&addr, sizeof(addr))) {
-		close(sock);
-		return -errno;
-	}
-
-	return sock;
-}
-
-/**
- * The primary: holds the device, hands over the descriptor, serves one
- * secondary and leaves when it disconnects.
- */
-static int
-primary(const char *cdev, const char *path, uint64_t offset)
-{
-	struct vfio_region_info region = {.index = 0};
-	struct iommufd iommufd = {0};
-	struct vfio_cdev dev = {0};
-	char byte;
-	void *bar0;
-	int listener = -1, sock = -1;
-	int err;
-
-	err = iommufd_open(&iommufd);
-	if (err) {
-		say("primary", "iommufd_open()", strerror(-err));
-		return err;
-	}
-
-	err = iommufd_ioas_alloc(&iommufd);
-	if (err) {
-		say("primary", "iommufd_ioas_alloc()", strerror(-err));
-		return err;
-	}
-
-	err = vfio_cdev_open(cdev, &dev);
-	if (err) {
-		say("primary", "vfio_cdev_open()", strerror(-err));
-		return err;
-	}
-
-	err = iommufd_bind(&iommufd, &dev);
-	if (err) {
-		say("primary", "iommufd_bind()", strerror(-err));
-		return err;
-	}
-
-	err = iommufd_attach(&iommufd, &dev);
-	if (err) {
-		say("primary", "iommufd_attach()", strerror(-err));
-		return err;
-	}
-	say("primary", "bind and attach", "ok");
-
-	if (vfio_device_get_region_info(dev.fd, &region)) {
-		say("primary", "GET_REGION_INFO(BAR0)", strerror(errno));
-		return -errno;
-	}
-
-	bar0 = vfio_map_region(dev.fd, region.size, region.offset);
-	if (bar0 == MAP_FAILED) {
-		say("primary", "mmap(BAR0)", strerror(errno));
-		return -errno;
-	}
-	printf("  [primary]   %-28s 0x%08" PRIx32 " 0x%08" PRIx32 "\n", "host read",
-	       mmio_read32(bar0, offset), mmio_read32(bar0, offset + 4));
-
-	listener = listen_at(path);
-	if (listener < 0) {
-		say("primary", "listen()", strerror(-listener));
-		return listener;
-	}
-	say("primary", "listening", path);
-
-	sock = accept(listener, NULL, NULL);
-	if (sock < 0) {
-		say("primary", "accept()", strerror(errno));
-		close(listener);
-		return -errno;
-	}
-
-	err = send_fd(sock, dev.fd);
-	if (err) {
-		say("primary", "send device fd", strerror(-err));
-		close(sock);
-		close(listener);
-		return err;
-	}
-	say("primary", "send device fd", "ok");
-
-	/* Hold everything open until the secondary is done with it. */
-	while (read(sock, &byte, 1) > 0) {
-	}
-	say("primary", "secondary disconnected", "ok");
-
-	close(sock);
-	close(listener);
-	unlink(path);
-
-	return 0;
-}
+#include "probe_vfio_share_gpu.h"
 
 int
 main(int argc, char *argv[])
 {
-	const uint64_t offset = 0;
-	int err;
-
-	setvbuf(stdout, NULL, _IOLBF, 0);
-
-	if (argc == 4 && !strcmp(argv[1], "primary")) {
-		printf("vfio_share_gpu_probe primary: %s\n", argv[2]);
-		err = primary(argv[2], argv[3], offset);
-	} else if (argc == 3 && !strcmp(argv[1], "standalone")) {
-		printf("vfio_share_gpu_probe standalone: %s\n", argv[2]);
-		err = standalone(argv[2], offset);
-	} else if (argc == 3 && !strcmp(argv[1], "secondary")) {
-		int sock = connect_to(argv[2]);
-
-		printf("vfio_share_gpu_probe secondary: %s\n", argv[2]);
-		if (sock < 0) {
-			say("secondary", "connect()", strerror(-sock));
-			return EXIT_FAILURE;
-		}
-
-		err = secondary(sock, offset);
-		close(sock);
-	} else {
-		fprintf(stderr, "usage: %s primary <cdev> <socket>\n", argv[0]);
-		fprintf(stderr, "       %s secondary <socket>\n", argv[0]);
-		fprintf(stderr, "       %s standalone <cdev>\n", argv[0]);
-		return 2;
-	}
-
-	return err ? EXIT_FAILURE : EXIT_SUCCESS;
+	return share_probe_main(argc, argv);
 }

--- a/tools/upcie_probe_vfio_share_gpu_hip.c
+++ b/tools/upcie_probe_vfio_share_gpu_hip.c
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * Delegated MMIO probe, HIP flavour
+ *
+ * ROCm has no kernel-compilation path in this project, so the device-side read
+ * goes through hipMemcpyDtoH rather than an SM. That is weaker evidence than
+ * the CUDA flavour gives, and it is enough for the question actually being
+ * asked, which is whether hipHostRegister accepts I/O memory at all.
+ *
+ * See tools/README.md.
+ */
+
+#include <upcie/upcie_hip.h>
+
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+
+#define SHARE_PROBE_REGISTER_NAME "hipHostRegister(IoMemory)"
+#define SHARE_PROBE_READ_NAME "copy-engine read"
+
+static char g_why[64];
+
+static const char *
+share_probe_why(void)
+{
+	return g_why;
+}
+
+static int
+share_probe_rt_init(void)
+{
+	if (hipInit(0) || hipSetDevice(0)) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int
+share_probe_register(void *addr, size_t nbytes)
+{
+	hipError_t herr = hipHostRegister(addr, nbytes, hipHostRegisterIoMemory);
+
+	if (herr == hipSuccess) {
+		return 0;
+	}
+
+	snprintf(g_why, sizeof(g_why), "%s", hipGetErrorName(herr));
+
+	return (int)herr;
+}
+
+static int
+share_probe_read(const void *addr, uint32_t *out)
+{
+	void *devptr = NULL;
+	hipError_t herr;
+
+	herr = hipHostGetDevicePointer(&devptr, (void *)addr, 0);
+	if (herr != hipSuccess) {
+		snprintf(g_why, sizeof(g_why), "%s", hipGetErrorName(herr));
+		return (int)herr;
+	}
+
+	herr = hipMemcpyDtoH(out, devptr, 2 * sizeof(uint32_t));
+
+	return herr == hipSuccess ? 0 : (int)herr;
+}
+
+#include "probe_vfio_share_gpu.h"
+
+int
+main(int argc, char *argv[])
+{
+	return share_probe_main(argc, argv);
+}

--- a/tools/upcie_probe_vram_ioas_cuda.c
+++ b/tools/upcie_probe_vram_ioas_cuda.c
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * VRAM into an IOAS, CUDA flavour
+ *
+ * See tools/README.md.
+ */
+
+#include <upcie/upcie_cuda.h>
+
+static CUdeviceptr g_ptr;
+
+static int
+vram_ioas_probe_rt_init(void)
+{
+	CUcontext ctx;
+	CUdevice dev;
+
+	if (cuInit(0) || cuDeviceGet(&dev, 0) || cuDevicePrimaryCtxRetain(&ctx, dev) ||
+	    cuCtxSetCurrent(ctx)) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int
+vram_ioas_probe_alloc_export(size_t nbytes, int *dmabuf_fd)
+{
+	CUresult cr;
+
+	cr = cuMemAlloc(&g_ptr, nbytes);
+	if (cr != CUDA_SUCCESS) {
+		return (int)cr;
+	}
+
+	cr = cuMemGetHandleForAddressRange(dmabuf_fd, g_ptr, nbytes,
+					   CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
+
+	return cr == CUDA_SUCCESS ? 0 : (int)cr;
+}
+
+#include "probe_vram_ioas.h"
+
+int
+main(void)
+{
+	return vram_ioas_probe_run(2 << 20);
+}

--- a/tools/upcie_probe_vram_ioas_hip.c
+++ b/tools/upcie_probe_vram_ioas_hip.c
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) Simon Andreas Frimann Lund <os@safl.dk>
+
+/**
+ * VRAM into an IOAS, HIP flavour
+ *
+ * See tools/README.md.
+ */
+
+#include <upcie/upcie_hip.h>
+
+static void *g_ptr;
+
+static int
+vram_ioas_probe_rt_init(void)
+{
+	if (hipInit(0) || hipSetDevice(0)) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int
+vram_ioas_probe_alloc_export(size_t nbytes, int *dmabuf_fd)
+{
+	hipError_t herr;
+
+	herr = hipMalloc(&g_ptr, nbytes);
+	if (herr != hipSuccess) {
+		return (int)herr;
+	}
+
+	herr = hipMemGetHandleForAddressRange(dmabuf_fd, (hipDeviceptr_t)g_ptr, nbytes,
+					      hipMemRangeHandleTypeDmaBufFd, 0);
+
+	return herr == hipSuccess ? 0 : (int)herr;
+}
+
+#include "probe_vram_ioas.h"
+
+int
+main(void)
+{
+	return vram_ioas_probe_run(2 << 20);
+}


### PR DESCRIPTION
The probes under `tools/` report what a runtime or the kernel actually does, as
opposed to `tests/`, which assert what uPCIe requires. They print and exit zero;
they do not fail when the answer is inconvenient.

They were carried along in safl/upcie#59 and safl/upcie#63 because that is where
they were needed. They belong on their own: they touch `tools/` and one
`subdir('tools')` line, and depend on nothing either of those branches adds.

Draft because the questions they answer are still moving. The kernel refuses
`IOMMU_IOAS_MAP_FILE` on a GPU-exported dma-buf today, and if that changes then
what `upcie_probe_vram_ioas_{cuda,hip}` reports changes with it.

## Worth a careful look

**The flavour contract in `probe_dmabuf.h`.** A flavour defines three functions,
includes the header, and calls `probe_run()`. The functions are prototyped in
the header rather than described only in prose, so a flavour missing one, or
defining it with another signature, is diagnosed at the prototype instead of at
the point of use or at link time.

**The fallback in `upcie_probe_vfio_share.c`.** `IOMMU_IOAS_MAP_FILE` arrived in
Linux 6.14, and Debian trixie and Ubuntu noble ship UAPI headers predating it,
so the probe maps the memfd through `IOMMU_IOAS_MAP` over a host mapping there
instead. The label it prints says which way the mapping was made.

## Verification

Every commit builds on its own, checked in a loop over the eight. The CUDA
flavours build on an NVIDIA RTX A6000 host with CUDA 13.3, and the HIP flavours
on an AMD Radeon RX 7800 XT host, both after this branch was pushed; before that
they had never been configured, and `tools/meson.build` turned out to name a
`.cu` file that does not exist and to declare two HIP executables twice while
leaving a third undeclared. CI cannot see any of that, since neither toolchain
is present in it.

What the probes report was measured earlier on those same two cards, and the
findings are recorded in `tools/README.md`. That measurement predates this
branch and was not repeated; only the builds were. Nothing here was run against
a controller.

The contract in `probe_dmabuf.h` was checked with a stub flavour, both complete
and with a function withheld, to confirm the prototypes catch it. Both sides of
the `IOMMU_IOAS_MAP_FILE` guard were compiled, the fallback by forcing the guard
off, since this machine's headers have the symbol. `clang-format` is clean
across the branch.

Assisted-by: Claude Code:claude-opus-5
