### PR TITLE
fix(upcie): guard the _GNU_SOURCE definition

### DIFF
--- a/include/upcie/upcie.h
+++ b/include/upcie/upcie.h
@@ -36,7 +36,9 @@
 #ifndef UPCIE_H
 #define UPCIE_H
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Defining `_GNU_SOURCE` unconditionally warns in every consumer that already
sets it, which is the usual arrangement, since the definition only takes
effect before the first libc header is read. xNVMe sets it project-wide and
got the warning on every translation unit reaching this header; with the guard
it gets none.

Worth knowing that the unguarded define was load-bearing in a fragile way as
well: a translation unit that includes a libc header before `upcie.h` never
gets `_GNU_SOURCE` at all, and then fails to compile on `struct ucred` in
`nvme_cplane.h`. The guard does not fix that, it just stops the header
fighting consumers that set the macro properly.

Split out of the control-plane work because it fixes something already on main
rather than anything that series introduces.

Assisted-by: Claude Code:claude-opus-5
